### PR TITLE
Fixing an issue when fetch() throws exceptions

### DIFF
--- a/src/DataCollector/GuzzleDataCollector.php
+++ b/src/DataCollector/GuzzleDataCollector.php
@@ -89,8 +89,17 @@ class GuzzleDataCollector extends DataCollector
         if ($response) {
             $transfer = $stats->getHandlerStats();
             $url = (string)$request->getUri();
+            $transfer['requestHeaders'] = $request->getHeaders();
             $transfer['headers'] = $response->getHeaders();
             $transfer['body'] = (string)$response->getBody();
+
+            $headersLower = array_change_key_case($transfer['headers'], CASE_LOWER);
+            if (array_key_exists('content-type', $headersLower)
+                && stristr($headersLower['content-type'][0], 'application/json') !== false
+            ) {
+                $transfer['body'] = json_encode(json_decode($transfer['body']), JSON_PRETTY_PRINT);
+            }
+
             $transfer['cacheKey'] = md5($url);
             $this->data['requests'][$url] = [$transfer];
             if (!array_key_exists($response->getStatusCode(), $this->data['statuses'])) {

--- a/src/Fixtures/FixtureService.php
+++ b/src/Fixtures/FixtureService.php
@@ -247,12 +247,16 @@ class FixtureService implements ServiceInterface
         }
 
         // Pass through to the original service to allow Guzzle to do it's thang:
-        $realResponse = $this->originalService->fetch($query, $raw);
-
-        // If we did mock something, unregister it to allow other requests to go through unchanged:
-        if ($match) {
-            $this->originalService->setClient($realClient);
-            $this->originalService->setCache($realCache);
+        $realResponse = null;
+        try {
+            $realResponse = $this->originalService->fetch($query, $raw);
+        } catch (\Exception $e) {
+            throw $e;
+        } finally {
+            if ($match) {
+                $this->originalService->setClient($realClient);
+                $this->originalService->setCache($realCache);
+            }
         }
 
         return $realResponse;

--- a/tests/DataCollector/GuzzleDataCollectorTest.php
+++ b/tests/DataCollector/GuzzleDataCollectorTest.php
@@ -62,7 +62,12 @@ class GuzzleDataCollectorTest extends TestCase
                         'http_code' => 200,
                         'body' => 'Mock Body',
                         'cacheKey' => 'ecb044e9c5e831a21ec02105152f584f',
-                        'headers' => []
+                        'headers' => [],
+                        'requestHeaders' => [
+                            'Host' => [
+                                'example.com'
+                            ]
+                        ]
                     ]
                 ]
             ],

--- a/views/guzzle.html.twig
+++ b/views/guzzle.html.twig
@@ -115,10 +115,20 @@
                 <tr class="guzzle-request-additional">
                     <td colspan="7">
                         <p>
-                            <a href="#headers_{{ i }}" class="toggle-link">Toggle Headers</a>
-                            | <a href="#body_{{ i }}" class="toggle-link">Toggle Body</a>
+                            <a href="#request_headers_{{ i }}" class="toggle-link">Request Headers</a>
+                            | <a href="#headers_{{ i }}" class="toggle-link">Response Headers</a>
+                            | <a href="#body_{{ i }}" class="toggle-link">Response Body</a>
                         </p>
 
+                        <table class="headers-table" id="request_headers_{{ i }}" style="display: none;">
+                            <caption>Headers</caption>
+                            {% for header,value in r.requestHeaders %}
+                                <tr>
+                                    <th>{{ header }}</th>
+                                    <td>{{ value.0 }}</td>
+                                </tr>
+                            {% endfor %}
+                        </table>
                         <pre class="guzzle-code" id="body_{{ i }}" style="display: none;"><code>{{ r.body }}</code></pre>
                         <table class="headers-table" id="headers_{{ i }}" style="display: none;">
                             <caption>Headers</caption>


### PR DESCRIPTION
When fetch throws an exception, the fixtures do not reset the guzzle client, resulting in real requests attempting to use Mocks.

This PR also adds the Request headers to the profiler and pretty printing JSON responses.