### PR TITLE
Bugfix/data collector

### DIFF
--- a/src/DataCollector/GuzzleDataCollector.php
+++ b/src/DataCollector/GuzzleDataCollector.php
@@ -100,8 +100,11 @@ class GuzzleDataCollector extends DataCollector
                 $transfer['body'] = json_encode(json_decode($transfer['body']), JSON_PRETTY_PRINT);
             }
 
-            $transfer['cacheKey'] = md5($url);
-            $this->data['requests'][$url] = [$transfer];
+            if (!array_key_exists($url, $this->data['requests'])) {
+                $this->data['requests'][$url] = [];
+            }
+
+            $this->data['requests'][$url][] = $transfer;
             if (!array_key_exists($response->getStatusCode(), $this->data['statuses'])) {
                 $this->data['statuses'][$response->getStatusCode()] = 0;
             }

--- a/tests/DataCollector/GuzzleDataCollectorTest.php
+++ b/tests/DataCollector/GuzzleDataCollectorTest.php
@@ -61,7 +61,6 @@ class GuzzleDataCollectorTest extends TestCase
                         'total_time' => 5,
                         'http_code' => 200,
                         'body' => 'Mock Body',
-                        'cacheKey' => 'ecb044e9c5e831a21ec02105152f584f',
                         'headers' => [],
                         'requestHeaders' => [
                             'Host' => [

--- a/views/guzzle.html.twig
+++ b/views/guzzle.html.twig
@@ -115,12 +115,12 @@
                 <tr class="guzzle-request-additional">
                     <td colspan="7">
                         <p>
-                            <a href="#request_headers_{{ i }}" class="toggle-link">Request Headers</a>
-                            | <a href="#headers_{{ i }}" class="toggle-link">Response Headers</a>
-                            | <a href="#body_{{ i }}" class="toggle-link">Response Body</a>
+                            <a href="#request_headers_{{ i~loop.index0 }}" class="toggle-link">Request Headers</a>
+                            | <a href="#headers_{{ i~loop.index0 }}" class="toggle-link">Response Headers</a>
+                            | <a href="#body_{{ i~loop.index0 }}" class="toggle-link">Response Body</a>
                         </p>
 
-                        <table class="headers-table" id="request_headers_{{ i }}" style="display: none;">
+                        <table class="headers-table" id="request_headers_{{ i~loop.index0 }}" style="display: none;">
                             <caption>Headers</caption>
                             {% for header,value in r.requestHeaders %}
                                 <tr>
@@ -129,8 +129,8 @@
                                 </tr>
                             {% endfor %}
                         </table>
-                        <pre class="guzzle-code" id="body_{{ i }}" style="display: none;"><code>{{ r.body }}</code></pre>
-                        <table class="headers-table" id="headers_{{ i }}" style="display: none;">
+                        <pre class="guzzle-code" id="body_{{ i~loop.index0 }}" style="display: none;"><code>{{ r.body }}</code></pre>
+                        <table class="headers-table" id="headers_{{ i~loop.index0 }}" style="display: none;">
                             <caption>Headers</caption>
                             {% for header,value in r.headers %}
                                 <tr>

--- a/views/guzzle.html.twig
+++ b/views/guzzle.html.twig
@@ -89,7 +89,6 @@
                 <th>Connect Time (ms)</th>
                 <th>Request Size (bytes)</th>
                 <th>Download Speed (bytes/s)</th>
-                <th>Cache Key</th>
             </tr>
             </thead>
             <tbody>


### PR DESCRIPTION
The Guzzle profiler tab would not render all requests collected. Now it does :)

Have also had to drop the cache key from the output as it's no longer available to the data collector.