### PR TITLE
Exceptions defined as non-error responses can now be cached.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -295,16 +295,16 @@
         },
         {
             "name": "psr/http-message",
-            "version": "1.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-message.git",
-                "reference": "85d63699f0dbedb190bbd4b0d2b9dc707ea4c298"
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-message/zipball/85d63699f0dbedb190bbd4b0d2b9dc707ea4c298",
-                "reference": "85d63699f0dbedb190bbd4b0d2b9dc707ea4c298",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
                 "shasum": ""
             },
             "require": {
@@ -332,6 +332,7 @@
                 }
             ],
             "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
             "keywords": [
                 "http",
                 "http-message",
@@ -340,7 +341,7 @@
                 "request",
                 "response"
             ],
-            "time": "2015-05-04 20:22:00"
+            "time": "2016-08-06 14:39:51"
         },
         {
             "name": "solution10/circuitbreaker",
@@ -942,16 +943,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "5.4.8",
+            "version": "5.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "3132365e1430c091f208e120b8845d39c25f20e6"
+                "reference": "08745ede58cb02b4043adadc09a01c09e698e3f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3132365e1430c091f208e120b8845d39c25f20e6",
-                "reference": "3132365e1430c091f208e120b8845d39c25f20e6",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/08745ede58cb02b4043adadc09a01c09e698e3f7",
+                "reference": "08745ede58cb02b4043adadc09a01c09e698e3f7",
                 "shasum": ""
             },
             "require": {
@@ -990,7 +991,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.4.x-dev"
+                    "dev-master": "5.5.x-dev"
                 }
             },
             "autoload": {
@@ -1016,20 +1017,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-07-26 14:48:00"
+            "time": "2016-08-25 04:45:28"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "3.2.3",
+            "version": "3.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "b13d0d9426ced06958bd32104653526a6c998a52"
+                "reference": "8f444748e174e49d5bd2bd7a9bebbf44edbb55fb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/b13d0d9426ced06958bd32104653526a6c998a52",
-                "reference": "b13d0d9426ced06958bd32104653526a6c998a52",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/8f444748e174e49d5bd2bd7a9bebbf44edbb55fb",
+                "reference": "8f444748e174e49d5bd2bd7a9bebbf44edbb55fb",
                 "shasum": ""
             },
             "require": {
@@ -1075,7 +1076,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2016-06-12 07:37:26"
+            "time": "2016-08-24 16:58:26"
         },
         {
             "name": "pimple/pimple",
@@ -1324,23 +1325,23 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "1.3.7",
+            "version": "1.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "4e8f0da10ac5802913afc151413bc8c53b6c2716"
+                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/4e8f0da10ac5802913afc151413bc8c53b6c2716",
-                "reference": "4e8f0da10ac5802913afc151413bc8c53b6c2716",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/be2c607e43ce4c89ecd60e75c6a85c126e754aea",
+                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^4.8 || ^5.0"
             },
             "type": "library",
             "extra": {
@@ -1370,7 +1371,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-05-17 03:18:57"
+            "time": "2016-08-18 05:49:44"
         },
         {
             "name": "sebastian/exporter",
@@ -1676,16 +1677,16 @@
         },
         {
             "name": "silex/silex",
-            "version": "v2.0.2",
+            "version": "v2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/silexphp/Silex.git",
-                "reference": "7420ac96195ea7eb6f1e11dc273be49359dd50ad"
+                "reference": "fd0852ebfa0a4cf1e17d746bb81962ec69bbb6d1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/silexphp/Silex/zipball/7420ac96195ea7eb6f1e11dc273be49359dd50ad",
-                "reference": "7420ac96195ea7eb6f1e11dc273be49359dd50ad",
+                "url": "https://api.github.com/repos/silexphp/Silex/zipball/fd0852ebfa0a4cf1e17d746bb81962ec69bbb6d1",
+                "reference": "fd0852ebfa0a4cf1e17d746bb81962ec69bbb6d1",
                 "shasum": ""
             },
             "require": {
@@ -1757,21 +1758,21 @@
             "keywords": [
                 "microframework"
             ],
-            "time": "2016-06-14 09:27:51"
+            "time": "2016-08-22 17:50:21"
         },
         {
             "name": "silex/web-profiler",
-            "version": "v2.0.1",
+            "version": "v2.0.2",
             "target-dir": "Silex/Provider",
             "source": {
                 "type": "git",
                 "url": "https://github.com/silexphp/Silex-WebProfiler.git",
-                "reference": "605ebe9d16eb9597ab42603d1b4bec595ebf677d"
+                "reference": "e0fff6fb6282eaa73126e5a6a4dd9a258f9d771b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/silexphp/Silex-WebProfiler/zipball/605ebe9d16eb9597ab42603d1b4bec595ebf677d",
-                "reference": "605ebe9d16eb9597ab42603d1b4bec595ebf677d",
+                "url": "https://api.github.com/repos/silexphp/Silex-WebProfiler/zipball/e0fff6fb6282eaa73126e5a6a4dd9a258f9d771b",
+                "reference": "e0fff6fb6282eaa73126e5a6a4dd9a258f9d771b",
                 "shasum": ""
             },
             "require": {
@@ -1813,7 +1814,7 @@
             ],
             "description": "A WebProfiler for Silex",
             "homepage": "http://silex.sensiolabs.org/",
-            "time": "2016-06-15 07:44:40"
+            "time": "2016-08-23 17:38:28"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -2688,28 +2689,29 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.0.2",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "30eed06dd6bc88410a4ff7f77b6d22f3ce13dbde"
+                "reference": "bb2d123231c095735130cc8f6d31385a44c7b308"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/30eed06dd6bc88410a4ff7f77b6d22f3ce13dbde",
-                "reference": "30eed06dd6bc88410a4ff7f77b6d22f3ce13dbde",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/bb2d123231c095735130cc8f6d31385a44c7b308",
+                "reference": "bb2d123231c095735130cc8f6d31385a44c7b308",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^5.3.3|^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.6"
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "1.2-dev"
                 }
             },
             "autoload": {
@@ -2733,7 +2735,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2015-08-24 13:29:44"
+            "time": "2016-08-09 15:02:57"
         }
     ],
     "aliases": [],

--- a/src/Stubs/Query.php
+++ b/src/Stubs/Query.php
@@ -2,6 +2,8 @@
 
 namespace BBC\iPlayerRadio\WebserviceKit\Stubs;
 
+use GuzzleHttp\Exception\ClientException;
+
 class Query extends \BBC\iPlayerRadio\WebserviceKit\Query
 {
     protected $endpoint = 'webservicekit';

--- a/src/Stubs/Query404Ok.php
+++ b/src/Stubs/Query404Ok.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace BBC\iPlayerRadio\WebserviceKit\Stubs;
+
+use GuzzleHttp\Exception\ClientException;
+
+class Query404Ok extends Query
+{
+    /**
+     * Given an Exception, return whether this should be considered a "failed" response and the breaker and monitoring
+     * informed of it. Useful for when you don't want to trigger alarms because of 404s etc that Guzzle considers
+     * to be Exceptions.
+     *
+     * @param   \Exception $e
+     * @return  bool
+     */
+    public function isFailureState(\Exception $e)
+    {
+        if ($e instanceof ClientException && $e->getResponse()->getStatusCode() === 404) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/tests/ServiceTest.php
+++ b/tests/ServiceTest.php
@@ -10,6 +10,7 @@ use BBC\iPlayerRadio\WebserviceKit\QueryInterface;
 use BBC\iPlayerRadio\WebserviceKit\Stubs\Monitoring;
 use BBC\iPlayerRadio\WebserviceKit\Stubs\OtherQuery;
 use BBC\iPlayerRadio\WebserviceKit\Stubs\Query;
+use BBC\iPlayerRadio\WebserviceKit\Stubs\Query404Ok;
 use Doctrine\Common\Cache\ArrayCache;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ConnectException;
@@ -312,6 +313,19 @@ class ServiceTest extends TestCase
         $this->assertEquals(
             '{"message": "hi there"}',
             $service->getCache()->getAdapter()->fetch($query->getCacheKey())['payload']['body']
+        );
+    }
+
+    public function testErrorStateCanBeCached()
+    {
+        $service = $this->getMockedService([404]);
+        $query = new Query404Ok();
+        $query->setCircuitBreaker(new CircuitBreaker('webservicekit_tests', new ArrayCache()));
+
+        $service->fetch($query);
+
+        $this->assertTrue(
+            $service->getCache()->getAdapter()->contains($query->getCacheKey())
         );
     }
 


### PR DESCRIPTION
In the past, error responses were not cached and instead relied on circuit breakers. However if an "error response" like a 404 is a valid response, then it should be cached just like a 200 type response.

This PR does exactly that.