### PR TITLE
Rationalizing fetch() and multiFetch().

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ $response = $service->fetch($query);
 You can also run multiple queries at the same time:
 
 ```php
-list($response1, $response2) = $service->multiFetch([$query1, $query2]);
+list($response1, $response2) = $service->fetch([$query1, $query2]);
 ```
 
 This is the most basic usage of WebserviceKit, there's a lot more power beneath the hood should you need it.

--- a/docs/02-service.md
+++ b/docs/02-service.md
@@ -66,13 +66,13 @@ WebserviceKit will handle the rest and you'll get the same result regardless of 
 
 If for whatever reason WebserviceKit could not fetch the data (timeout, bad response etc), you will instead get a `null`.
 
-You can also fetch multiple queries simultaneously using `multiFetch()`:
+You can also fetch multiple queries simultaneously using an array of queries:
 
 ```php
 $firstArticleQuery = (new ArticlesQuery())->setId(27);
 $secondArticleQuery = (new ArticlesQuery())->setId(28);
 
-list($firstArticle, $secondArticle) = $service->multiFetch([$firstArticleQuery, $secondArticleQuery]);
+list($firstArticle, $secondArticle) = $service->fetch([$firstArticleQuery, $secondArticleQuery]);
 ```
 
 These requests will happen together, asynchronously, and then return an array of results (expanded out above using `list()`).

--- a/src/ServiceInterface.php
+++ b/src/ServiceInterface.php
@@ -10,7 +10,7 @@ namespace BBC\iPlayerRadio\WebserviceKit;
  * @package     BBC\iPlayerRadio\WebserviceKit
  * @author      Alex Gisby <alex.gisby@bbc.co.uk>
  * @copyright   BBC
- * @see         docs/04-webservicekit.md
+ * @see         docs/02-service.md
  */
 interface ServiceInterface
 {
@@ -18,13 +18,12 @@ interface ServiceInterface
      * Fetches the service from the URL and hands off to the transformPayload function to do something useful
      * with it. Under the hood, this just uses multiFetch to reduce duplication.
      *
-     * @param           QueryInterface  $query
+     * @param           QueryInterface|QueryInterface[]  $query
      * @param           bool            $raw        Whether to ignore transformPayload or not.
      * @return          mixed
      * @throws          NoResponseException     When the cache is empty and the request fails.
-     * @uses            self::multiFetch()
      */
-    public function fetch(QueryInterface $query, $raw = false);
+    public function fetch($query, $raw = false);
 
     /**
      * Fetches multiple queries from the webservice simultaneously using multi-curl or similar.
@@ -34,6 +33,7 @@ interface ServiceInterface
      * @param   QueryInterface[]    $queries
      * @param   bool                $raw
      * @return  array               Array of transformPayload objects
+     * @deprecated  Use fetch() with an array instead
      */
     public function multiFetch(array $queries, $raw = false);
 }


### PR DESCRIPTION
I'm starting to really dislike having to use different methods for fetching single and multiple queries. This is a hangover from when the two implementations were different, but `fetch()` has been a proxy for `multiFetch()` for a long time now.

This PR:

- Moves all the fetching into `fetch()`
- Allows you to pass an array of queries into `fetch()` rather than having to call `multiFetch()`
- Deprecates `multiFetch()`
- Updated docs.

Whilst this is a fairly big code reshuffle, it has no user-facing impact. No unit tests were updated for this, so clients won't need to change their code, but it allows us to provide a cleaner API.

@stephencoe @mgurgel @jucke @Jayflux - how do you feel about this change? Did you like having separate methods for single and multiple queries, or does this way feel cleaner?