### PR TITLE
v1.1.0 - New features!

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         "silex/silex": "^2.0",
         "silex/web-profiler": "^2.0",
         "symfony/dom-crawler": "^3.0",
-        "symfony/css-selector": "^3.0"
+        "symfony/css-selector": "^3.0",
+        "bbc/ipr-resolver": "^0.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "1d24ee3715310549ee6ef7540212b133",
-    "content-hash": "1ee31ed3e1dd112659fa79116fd1a7b3",
+    "hash": "9b5f11cdf96be41660cc92912a5b3b36",
+    "content-hash": "6257a080e86b1c57331d25513f6a52af",
     "packages": [
         {
             "name": "bbc/ipr-cache",
@@ -186,16 +186,16 @@
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "1.2.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "c10d860e2a9595f8883527fa0021c7da9e65f579"
+                "reference": "2693c101803ca78b27972d84081d027fca790a1e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/c10d860e2a9595f8883527fa0021c7da9e65f579",
-                "reference": "c10d860e2a9595f8883527fa0021c7da9e65f579",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/2693c101803ca78b27972d84081d027fca790a1e",
+                "reference": "2693c101803ca78b27972d84081d027fca790a1e",
                 "shasum": ""
             },
             "require": {
@@ -233,7 +233,7 @@
             "keywords": [
                 "promise"
             ],
-            "time": "2016-05-18 16:56:05"
+            "time": "2016-11-18 17:47:58"
         },
         {
             "name": "guzzlehttp/psr7",
@@ -393,6 +393,46 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "bbc/ipr-resolver",
+            "version": "v0.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/bbc/ipr-php-resolver.git",
+                "reference": "af234d3929e3cde637fbed1c9ce70e4d874b0066"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/bbc/ipr-php-resolver/zipball/af234d3929e3cde637fbed1c9ce70e4d874b0066",
+                "reference": "af234d3929e3cde637fbed1c9ce70e4d874b0066",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0",
+                "squizlabs/php_codesniffer": "^2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "BBC\\iPlayerRadio\\Resolver\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alex Gisby",
+                    "email": "alex.gisby@bbc.co.uk"
+                }
+            ],
+            "description": "A dependency resolution library.",
+            "time": "2016-08-05 14:40:16"
+        },
         {
             "name": "doctrine/instantiator",
             "version": "1.0.5",
@@ -590,16 +630,16 @@
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "0.2",
+            "version": "0.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "b39c7a5b194f9ed7bd0dd345c751007a41862443"
+                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/b39c7a5b194f9ed7bd0dd345c751007a41862443",
-                "reference": "b39c7a5b194f9ed7bd0dd345c751007a41862443",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
+                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
                 "shasum": ""
             },
             "require": {
@@ -633,20 +673,20 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2016-06-10 07:14:17"
+            "time": "2016-11-25 06:54:22"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.6.1",
+            "version": "v1.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "58a8137754bc24b25740d4281399a4a3596058e0"
+                "reference": "6c52c2722f8460122f96f86346600e1077ce22cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/58a8137754bc24b25740d4281399a4a3596058e0",
-                "reference": "58a8137754bc24b25740d4281399a4a3596058e0",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/6c52c2722f8460122f96f86346600e1077ce22cb",
+                "reference": "6c52c2722f8460122f96f86346600e1077ce22cb",
                 "shasum": ""
             },
             "require": {
@@ -654,10 +694,11 @@
                 "php": "^5.3|^7.0",
                 "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
                 "sebastian/comparator": "^1.1",
-                "sebastian/recursion-context": "^1.0"
+                "sebastian/recursion-context": "^1.0|^2.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^2.0"
+                "phpspec/phpspec": "^2.0",
+                "phpunit/phpunit": "^4.8 || ^5.6.5"
             },
             "type": "library",
             "extra": {
@@ -695,7 +736,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2016-06-07 08:13:47"
+            "time": "2016-11-21 14:58:47"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -762,16 +803,16 @@
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.1",
+            "version": "1.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0"
+                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
-                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
+                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
                 "shasum": ""
             },
             "require": {
@@ -805,7 +846,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2015-06-21 13:08:43"
+            "time": "2016-10-03 07:40:28"
         },
         {
             "name": "phpunit/php-text-template",
@@ -894,16 +935,16 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.8",
+            "version": "1.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da"
+                "reference": "3b402f65a4cc90abf6e1104e388b896ce209631b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
-                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/3b402f65a4cc90abf6e1104e388b896ce209631b",
+                "reference": "3b402f65a4cc90abf6e1104e388b896ce209631b",
                 "shasum": ""
             },
             "require": {
@@ -939,20 +980,20 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2015-09-15 10:49:45"
+            "time": "2016-11-15 14:06:22"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "5.6.2",
+            "version": "5.6.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "cd13b23ac5a519a4708e00736c26ee0bb28b2e01"
+                "reference": "875145fabfa261fa9c1aea663dd29ddce92dca8f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/cd13b23ac5a519a4708e00736c26ee0bb28b2e01",
-                "reference": "cd13b23ac5a519a4708e00736c26ee0bb28b2e01",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/875145fabfa261fa9c1aea663dd29ddce92dca8f",
+                "reference": "875145fabfa261fa9c1aea663dd29ddce92dca8f",
                 "shasum": ""
             },
             "require": {
@@ -969,12 +1010,12 @@
                 "phpunit/php-text-template": "~1.2",
                 "phpunit/php-timer": "^1.0.6",
                 "phpunit/phpunit-mock-objects": "^3.2",
-                "sebastian/comparator": "~1.1",
+                "sebastian/comparator": "~1.2.2",
                 "sebastian/diff": "~1.2",
                 "sebastian/environment": "^1.3 || ^2.0",
-                "sebastian/exporter": "~1.2",
+                "sebastian/exporter": "~2.0",
                 "sebastian/global-state": "~1.0",
-                "sebastian/object-enumerator": "~1.0",
+                "sebastian/object-enumerator": "~2.0",
                 "sebastian/resource-operations": "~1.0",
                 "sebastian/version": "~1.0|~2.0",
                 "symfony/yaml": "~2.1|~3.0"
@@ -1021,27 +1062,27 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-10-25 07:40:25"
+            "time": "2016-11-21 15:23:34"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "3.4.0",
+            "version": "3.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "238d7a2723bce689c79eeac9c7d5e1d623bb9dc2"
+                "reference": "90a08f5deed5f7ac35463c161f2e8fa0e5652faf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/238d7a2723bce689c79eeac9c7d5e1d623bb9dc2",
-                "reference": "238d7a2723bce689c79eeac9c7d5e1d623bb9dc2",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/90a08f5deed5f7ac35463c161f2e8fa0e5652faf",
+                "reference": "90a08f5deed5f7ac35463c161f2e8fa0e5652faf",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.6 || ^7.0",
                 "phpunit/php-text-template": "^1.2",
-                "sebastian/exporter": "^1.2"
+                "sebastian/exporter": "^1.2 || ^2.0"
             },
             "conflict": {
                 "phpunit/phpunit": "<5.4.0"
@@ -1080,7 +1121,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2016-10-09 07:01:45"
+            "time": "2016-11-27 07:52:03"
         },
         {
             "name": "pimple/pimple",
@@ -1222,22 +1263,22 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "1.2.0",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22"
+                "reference": "6a1ed12e8b2409076ab22e3897126211ff8b1f7f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/937efb279bd37a375bcadf584dec0726f84dbf22",
-                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/6a1ed12e8b2409076ab22e3897126211ff8b1f7f",
+                "reference": "6a1ed12e8b2409076ab22e3897126211ff8b1f7f",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3",
                 "sebastian/diff": "~1.2",
-                "sebastian/exporter": "~1.2"
+                "sebastian/exporter": "~1.2 || ~2.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "~4.4"
@@ -1282,7 +1323,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2015-07-26 15:48:44"
+            "time": "2016-11-19 09:18:40"
         },
         {
             "name": "sebastian/diff",
@@ -1338,28 +1379,28 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "1.3.8",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea"
+                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/be2c607e43ce4c89ecd60e75c6a85c126e754aea",
-                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
+                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8 || ^5.0"
+                "phpunit/phpunit": "^5.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -1384,25 +1425,25 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-08-18 05:49:44"
+            "time": "2016-11-26 07:53:53"
         },
         {
             "name": "sebastian/exporter",
-            "version": "1.2.2",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4"
+                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/42c4c2eec485ee3e159ec9884f95b431287edde4",
-                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
+                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3",
-                "sebastian/recursion-context": "~1.0"
+                "sebastian/recursion-context": "~2.0"
             },
             "require-dev": {
                 "ext-mbstring": "*",
@@ -1411,7 +1452,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -1451,7 +1492,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-06-17 09:04:28"
+            "time": "2016-11-19 08:54:04"
         },
         {
             "name": "sebastian/global-state",
@@ -1506,21 +1547,21 @@
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "1.0.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "d4ca2fb70344987502567bc50081c03e6192fb26"
+                "reference": "96f8a3f257b69e8128ad74d3a7fd464bcbaa3b35"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/d4ca2fb70344987502567bc50081c03e6192fb26",
-                "reference": "d4ca2fb70344987502567bc50081c03e6192fb26",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/96f8a3f257b69e8128ad74d3a7fd464bcbaa3b35",
+                "reference": "96f8a3f257b69e8128ad74d3a7fd464bcbaa3b35",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.6",
-                "sebastian/recursion-context": "~1.0"
+                "sebastian/recursion-context": "~2.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "~5"
@@ -1528,7 +1569,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -1548,20 +1589,20 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2016-01-28 13:25:10"
+            "time": "2016-11-19 07:35:10"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "1.0.2",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "913401df809e99e4f47b27cdd781f4a258d58791"
+                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/913401df809e99e4f47b27cdd781f4a258d58791",
-                "reference": "913401df809e99e4f47b27cdd781f4a258d58791",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/2c3ba150cbec723aa057506e73a8d33bdb286c9a",
+                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a",
                 "shasum": ""
             },
             "require": {
@@ -1573,7 +1614,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -1601,7 +1642,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2015-11-11 19:50:13"
+            "time": "2016-11-19 07:33:16"
         },
         {
             "name": "sebastian/resource-operations",
@@ -1647,16 +1688,16 @@
         },
         {
             "name": "sebastian/version",
-            "version": "2.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "c829badbd8fdf16a0bad8aa7fa7971c029f1b9c5"
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c829badbd8fdf16a0bad8aa7fa7971c029f1b9c5",
-                "reference": "c829badbd8fdf16a0bad8aa7fa7971c029f1b9c5",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
                 "shasum": ""
             },
             "require": {
@@ -1686,7 +1727,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2016-02-04 12:56:52"
+            "time": "2016-10-03 07:35:21"
         },
         {
             "name": "silex/silex",
@@ -1775,17 +1816,17 @@
         },
         {
             "name": "silex/web-profiler",
-            "version": "v2.0.4",
+            "version": "v2.0.5",
             "target-dir": "Silex/Provider",
             "source": {
                 "type": "git",
                 "url": "https://github.com/silexphp/Silex-WebProfiler.git",
-                "reference": "db11b65f98939440d985042d8f76a7148af9155d"
+                "reference": "b44c4c8e70a43eb5e98372cffbeb6de3770c5805"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/silexphp/Silex-WebProfiler/zipball/db11b65f98939440d985042d8f76a7148af9155d",
-                "reference": "db11b65f98939440d985042d8f76a7148af9155d",
+                "url": "https://api.github.com/repos/silexphp/Silex-WebProfiler/zipball/b44c4c8e70a43eb5e98372cffbeb6de3770c5805",
+                "reference": "b44c4c8e70a43eb5e98372cffbeb6de3770c5805",
                 "shasum": ""
             },
             "require": {
@@ -1828,7 +1869,7 @@
             ],
             "description": "A WebProfiler for Silex",
             "homepage": "http://silex.sensiolabs.org/",
-            "time": "2016-10-27 01:28:31"
+            "time": "2016-11-21 23:51:53"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -1910,16 +1951,16 @@
         },
         {
             "name": "symfony/css-selector",
-            "version": "v3.1.6",
+            "version": "v3.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "ca809c64072e0fe61c1c7fb3c76cdc32265042ac"
+                "reference": "a37b3359566415a91cba55a2d95820b3fa1a9658"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/ca809c64072e0fe61c1c7fb3c76cdc32265042ac",
-                "reference": "ca809c64072e0fe61c1c7fb3c76cdc32265042ac",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/a37b3359566415a91cba55a2d95820b3fa1a9658",
+                "reference": "a37b3359566415a91cba55a2d95820b3fa1a9658",
                 "shasum": ""
             },
             "require": {
@@ -1959,20 +2000,20 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-06 11:02:40"
+            "time": "2016-11-03 08:04:31"
         },
         {
             "name": "symfony/debug",
-            "version": "v3.1.6",
+            "version": "v3.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "e2b3f74a67fc928adc3c1b9027f73e1bc01190a8"
+                "reference": "c058661c32f5b462722e36d120905940089cbd9a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/e2b3f74a67fc928adc3c1b9027f73e1bc01190a8",
-                "reference": "e2b3f74a67fc928adc3c1b9027f73e1bc01190a8",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/c058661c32f5b462722e36d120905940089cbd9a",
+                "reference": "c058661c32f5b462722e36d120905940089cbd9a",
                 "shasum": ""
             },
             "require": {
@@ -2016,20 +2057,20 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-06 11:02:40"
+            "time": "2016-11-15 12:55:20"
         },
         {
             "name": "symfony/dom-crawler",
-            "version": "v3.1.6",
+            "version": "v3.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dom-crawler.git",
-                "reference": "59eee3c76eb89f21857798620ebdad7a05ad14f4"
+                "reference": "1eb3b4d216e8db117218dd2bb7d23dfe67bdf518"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/59eee3c76eb89f21857798620ebdad7a05ad14f4",
-                "reference": "59eee3c76eb89f21857798620ebdad7a05ad14f4",
+                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/1eb3b4d216e8db117218dd2bb7d23dfe67bdf518",
+                "reference": "1eb3b4d216e8db117218dd2bb7d23dfe67bdf518",
                 "shasum": ""
             },
             "require": {
@@ -2072,11 +2113,11 @@
             ],
             "description": "Symfony DomCrawler Component",
             "homepage": "https://symfony.com",
-            "time": "2016-10-18 15:46:07"
+            "time": "2016-11-14 16:20:02"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v3.1.6",
+            "version": "v3.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
@@ -2136,16 +2177,16 @@
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v3.1.6",
+            "version": "v3.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "f21e5a8b88274b7720779aa88f9c02c6d6ec08d7"
+                "reference": "5a4c8099a1547fe451256e056180ad4624177017"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/f21e5a8b88274b7720779aa88f9c02c6d6ec08d7",
-                "reference": "f21e5a8b88274b7720779aa88f9c02c6d6ec08d7",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/5a4c8099a1547fe451256e056180ad4624177017",
+                "reference": "5a4c8099a1547fe451256e056180ad4624177017",
                 "shasum": ""
             },
             "require": {
@@ -2185,20 +2226,20 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "time": "2016-10-24 15:52:44"
+            "time": "2016-11-16 22:17:09"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v3.1.6",
+            "version": "v3.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "c235f1b13ba67012e283996a5427f22e2e04be14"
+                "reference": "674ac403c7b3742c2a988a86e3baf9aca2c696a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/c235f1b13ba67012e283996a5427f22e2e04be14",
-                "reference": "c235f1b13ba67012e283996a5427f22e2e04be14",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/674ac403c7b3742c2a988a86e3baf9aca2c696a0",
+                "reference": "674ac403c7b3742c2a988a86e3baf9aca2c696a0",
                 "shasum": ""
             },
             "require": {
@@ -2267,20 +2308,20 @@
             ],
             "description": "Symfony HttpKernel Component",
             "homepage": "https://symfony.com",
-            "time": "2016-10-27 02:38:31"
+            "time": "2016-11-21 02:44:20"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.2.0",
+            "version": "v1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "dff51f72b0706335131b00a7f49606168c582594"
+                "reference": "e79d363049d1c2128f133a2667e4f4190904f7f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/dff51f72b0706335131b00a7f49606168c582594",
-                "reference": "dff51f72b0706335131b00a7f49606168c582594",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/e79d363049d1c2128f133a2667e4f4190904f7f4",
+                "reference": "e79d363049d1c2128f133a2667e4f4190904f7f4",
                 "shasum": ""
             },
             "require": {
@@ -2292,7 +2333,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2-dev"
+                    "dev-master": "1.3-dev"
                 }
             },
             "autoload": {
@@ -2326,11 +2367,11 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-05-18 14:26:46"
+            "time": "2016-11-14 01:06:16"
         },
         {
             "name": "symfony/routing",
-            "version": "v3.1.6",
+            "version": "v3.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
@@ -2405,7 +2446,7 @@
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v3.1.6",
+            "version": "v3.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
@@ -2454,21 +2495,21 @@
         },
         {
             "name": "symfony/twig-bridge",
-            "version": "v3.1.6",
+            "version": "v3.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/twig-bridge.git",
-                "reference": "a75dfd56d7cf8df1843dcf44a0d6d4ef8b72440c"
+                "reference": "b66a3f12320fd4c04bc4d168ad7ecf79b341c835"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/twig-bridge/zipball/a75dfd56d7cf8df1843dcf44a0d6d4ef8b72440c",
-                "reference": "a75dfd56d7cf8df1843dcf44a0d6d4ef8b72440c",
+                "url": "https://api.github.com/repos/symfony/twig-bridge/zipball/b66a3f12320fd4c04bc4d168ad7ecf79b341c835",
+                "reference": "b66a3f12320fd4c04bc4d168ad7ecf79b341c835",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.5.9",
-                "twig/twig": "~1.27|~2.0"
+                "twig/twig": "~1.28|~2.0"
             },
             "require-dev": {
                 "symfony/asset": "~2.8|~3.0",
@@ -2531,20 +2572,20 @@
             ],
             "description": "Symfony Twig Bridge",
             "homepage": "https://symfony.com",
-            "time": "2016-10-24 15:52:44"
+            "time": "2016-11-14 16:20:02"
         },
         {
             "name": "symfony/web-profiler-bundle",
-            "version": "v3.1.6",
+            "version": "v3.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/web-profiler-bundle.git",
-                "reference": "051d666ab2a9ddb48fb9283d8b940aba055a6a84"
+                "reference": "bd7cfbf8ee670e2df6a4b5ce7a534b1d6c3139bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/web-profiler-bundle/zipball/051d666ab2a9ddb48fb9283d8b940aba055a6a84",
-                "reference": "051d666ab2a9ddb48fb9283d8b940aba055a6a84",
+                "url": "https://api.github.com/repos/symfony/web-profiler-bundle/zipball/bd7cfbf8ee670e2df6a4b5ce7a534b1d6c3139bd",
+                "reference": "bd7cfbf8ee670e2df6a4b5ce7a534b1d6c3139bd",
                 "shasum": ""
             },
             "require": {
@@ -2589,20 +2630,20 @@
             ],
             "description": "Symfony WebProfilerBundle",
             "homepage": "https://symfony.com",
-            "time": "2016-10-23 01:13:38"
+            "time": "2016-11-16 22:17:09"
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.1.6",
+            "version": "v3.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "7ff51b06c6c3d5cc6686df69004a42c69df09e27"
+                "reference": "9da375317228e54f4ea1b013b30fa47417e84943"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/7ff51b06c6c3d5cc6686df69004a42c69df09e27",
-                "reference": "7ff51b06c6c3d5cc6686df69004a42c69df09e27",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/9da375317228e54f4ea1b013b30fa47417e84943",
+                "reference": "9da375317228e54f4ea1b013b30fa47417e84943",
                 "shasum": ""
             },
             "require": {
@@ -2638,20 +2679,20 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-10-24 18:41:13"
+            "time": "2016-11-18 21:05:29"
         },
         {
             "name": "twig/twig",
-            "version": "v1.27.0",
+            "version": "v1.28.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "3c6c0033fd3b5679c6e1cb60f4f9766c2b424d97"
+                "reference": "b22ce0eb070e41f7cba65d78fe216de29726459c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/3c6c0033fd3b5679c6e1cb60f4f9766c2b424d97",
-                "reference": "3c6c0033fd3b5679c6e1cb60f4f9766c2b424d97",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/b22ce0eb070e41f7cba65d78fe216de29726459c",
+                "reference": "b22ce0eb070e41f7cba65d78fe216de29726459c",
                 "shasum": ""
             },
             "require": {
@@ -2659,12 +2700,12 @@
             },
             "require-dev": {
                 "symfony/debug": "~2.7",
-                "symfony/phpunit-bridge": "~2.7"
+                "symfony/phpunit-bridge": "~3.2@dev"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.27-dev"
+                    "dev-master": "1.28-dev"
                 }
             },
             "autoload": {
@@ -2699,24 +2740,24 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2016-10-25 19:17:17"
+            "time": "2016-11-23 18:41:40"
         },
         {
             "name": "webmozart/assert",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "bb2d123231c095735130cc8f6d31385a44c7b308"
+                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/bb2d123231c095735130cc8f6d31385a44c7b308",
-                "reference": "bb2d123231c095735130cc8f6d31385a44c7b308",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3|^7.0"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.6",
@@ -2725,7 +2766,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2-dev"
+                    "dev-master": "1.3-dev"
                 }
             },
             "autoload": {
@@ -2749,7 +2790,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-08-09 15:02:57"
+            "time": "2016-11-23 20:04:58"
         }
     ],
     "aliases": [],

--- a/docs/00-intro.md
+++ b/docs/00-intro.md
@@ -23,3 +23,5 @@ to RESTful style APIs especially suited for Service Oriented Architectures.
 - [Fixtures](./04-fixtures.md)
 - [Monitoring](./05-monitoring.md)
 - [Profiler](./06-profiler.md)
+- [Named Queries](./07-named-queries.md)
+- [Resolver Backend](./08-resolver-backend.md)

--- a/docs/02-service.md
+++ b/docs/02-service.md
@@ -82,6 +82,11 @@ WebserviceKit guarantees that you will always get the same number of results as 
 order, regardless of which response finished first. Put simply, in the above example, `$firstArticle` will always be the
 result of `$firstArticleQuery` regardless of cache state, response time or failure.
 
+> **Note**: *(new in v1.1.0)* WebserviceKit will automatically de-duplicate queries for you! If you pass the same query
+into the `fetch()` function twice (even if they are different objects), the library will only run it once, but return
+it twice, as if it did run it twice! This is invisible to you as a user, you shouldn't need to care, it's just mentioned
+here in case the output of the Profiler tab is confusing.
+
 ## Callbacks
 
 WebserviceKit provides a single callback point on the service; `beforeQuery()`. The reason for this sparseness is to

--- a/docs/07-named-queries.md
+++ b/docs/07-named-queries.md
@@ -22,7 +22,7 @@ you have common operation whereby you load an item by it's ID:
 $query = (new ItemsQuery())
     ->setParameter('id', '02374894483')
     ->setParameter('with-comments', 'true')
-    ->setParamter('limit', 1);
+    ->setParameter('limit', 1);
 ```
 
 Halfway through your project you realise you need to add another parameter to handle soft-deletes:
@@ -31,7 +31,7 @@ Halfway through your project you realise you need to add another parameter to ha
 $query = (new ItemsQuery())
     ->setParameter('id', '02374894483')
     ->setParameter('with-comments', 'true')
-    ->setParamter('limit', 1)
+    ->setParameter('limit', 1)
     ->setParameter('deleted', 'false');
 ```
 
@@ -91,7 +91,7 @@ class FindById implements NamedQueryInterface
         return (new ItemsQuery())
              ->setParameter('id', $this->id)
              ->setParameter('with-comments', 'true')
-             ->setParamter('limit', 1)
+             ->setParameter('limit', 1)
              ->setParameter('deleted', 'false');
     }
 

--- a/docs/07-named-queries.md
+++ b/docs/07-named-queries.md
@@ -1,0 +1,151 @@
+# Named Queries
+
+*Introduced in v1.1.0*
+
+- [Intro](#intro)
+- [Writing Named Queries](#writing-named-queries)
+    - [query()](#query)
+    - [processResults()](#process-results)
+- [Using Named Queries](#using-named-queries)
+
+## Intro
+
+WebserviceKit includes the concept of "Named Queries".
+
+A named query is a quick way of defining a common operation that you
+wish to abstract away from higher level users of your models. Perhaps
+you have common operation whereby you load an item by it's ID:
+
+```php
+// Given ItemsQuery is an instanceof BBC\iPlayerRadio\WebserviceKit\QueryInterface
+
+$query = (new ItemsQuery())
+    ->setParameter('id', '02374894483')
+    ->setParameter('with-comments', 'true')
+    ->setParamter('limit', 1);
+```
+
+Halfway through your project you realise you need to add another parameter to handle soft-deletes:
+
+```php
+$query = (new ItemsQuery())
+    ->setParameter('id', '02374894483')
+    ->setParameter('with-comments', 'true')
+    ->setParamter('limit', 1)
+    ->setParameter('deleted', 'false');
+```
+
+And now you have to go hunt down every time you're using this query. Annoying.
+
+Named queries allow you to define your operations as *intentions* rather than hard queries. This means you can
+change your underlying implementation at any time, and code using those Named Queries doesn't have to care!
+
+## Writing Named Queries
+
+A named query is simply a class that implements the NamedQueryInterface:
+
+```php
+interface NamedQueryInterface
+{
+    /**
+     * Returns the query to execute against a WebserviceKit\Service instance.
+     *
+     * @return  \BBC\iPlayerRadio\WebserviceKit\QueryInterface
+     */
+    public function query();
+
+    /**
+     * Allows the NamedQuery to perform any additional processing on the result
+     * before returning it.
+     *
+     * @param   mixed $results
+     * @return  mixed
+     */
+    public function processResults($results);
+}
+```
+
+So for the example given in the Intro, we could write the following:
+
+```php
+<?php
+
+use BBC\iPlayerRadio\WebserviceKit\NamedQueryInterface;
+
+class FindById implements NamedQueryInterface
+{
+    protected $id;
+    
+    public function __construct($id)
+    {
+        $this->id = $id;
+    }
+    
+    /**
+     * Returns the query to execute against a WebserviceKit\Service instance.
+     *
+     * @return  \BBC\iPlayerRadio\WebserviceKit\QueryInterface|\BBC\iPlayerRadio\WebserviceKit\QueryInterface[]
+     */
+    public function query()
+    {
+        return (new ItemsQuery())
+             ->setParameter('id', $this->id)
+             ->setParameter('with-comments', 'true')
+             ->setParamter('limit', 1)
+             ->setParameter('deleted', 'false');
+    }
+
+    /**
+     * Allows the NamedQuery to perform any additional processing on the result
+     * before returning it.
+     *
+     * @param   mixed $results
+     * @return  mixed
+     */
+    public function processResults($results)
+    {
+        return $results;     
+    }
+}
+
+```
+
+### query()
+
+The `query()` method is responsible for returning the query (or array of queries) to run.
+
+### processResults()
+
+For certain named queries, there may be an operation you always perform on the result to complete the operation. For
+instance, perhaps our ItemsQuery always returns an array of objects, but for our FindById it would be much more
+useful if we return the first item.
+
+Therefore, we could write a `processResults()` function that looks like:
+
+```php
+/**
+ * Allows the NamedQuery to perform any additional processing on the result
+ * before returning it.
+ *
+ * @param   mixed $results
+ * @return  mixed
+ */
+public function processResults($results)
+{
+    return (array_key_exists(0, $results)? $results[0] : false;     
+}
+```
+
+Note: this is **in addition to** the transformPayload() on the `QueryInterface` instance! `transformPayload` is run
+first, followed by `processResults`.
+
+## Using Named Queries
+
+Named Queries behave exactly like a standard QueryInterface object, you can pass them into `fetch()`:
+
+```php
+$q1 = new FindById('id1');
+$q2 = new FindById('id2');
+
+list($r1, $r2) = $service->fetch([$q1, $q2]);
+```

--- a/docs/08-resolver-backend.md
+++ b/docs/08-resolver-backend.md
@@ -1,0 +1,51 @@
+# Resolver Backend
+
+*New in v1.1.0*
+
+If you're a user of the [BBC\iPlayerRadio\Resolver](https://github.com/bbc/ipr-php-resolver) library, you'll
+probably want to hook it up to WebserviceKit so that you can use queries as resolutions.
+
+WebserviceKit provides a Resolver Backend to do exactly that:
+
+```php
+// Create a service instance:
+$service = new \BBC\iPlayerRadio\WebserviceKit\Service(
+    new \GuzzleHttp\Client(),
+    new \BBC\iPlayerRadio\Cache\Cache(new \Doctrine\Common\Cache\RedisCache())
+);
+
+$resolver = new \BBC\iPlayerRadio\Resolver\Resolver();
+
+// Register the backend:
+$resolver->addBackend(
+    new \BBC\iPlayerRadio\WebserviceKit\WebserviceKitResolverBackend($service)
+);
+```
+
+You can now yield `QueryInterface` or `NamedQueryInterface` instances from your `requires` blocks:
+
+```php
+class ItemQuery extends \BBC\iPlayerRadio\WebserviceKit\Query
+{
+    // ...
+}
+
+class Article implements \BBC\iPlayerRadio\Resolver\HasRequirements
+{    
+    protected $id;
+    
+    public function __construct($id)
+    {
+        $this->id = $id;
+    }
+    
+    public function requires(array $flags = [])
+    {
+        $this->data = (yield new ItemQuery($this->id));  
+    }   
+}
+
+$article = new Article('my-id');
+$resolver->resolve($article);
+
+```

--- a/src/NamedQueryInterface.php
+++ b/src/NamedQueryInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace BBC\iPlayerRadio\WebserviceKit;
+
+/**
+ * Interface NamedQueryInterface
+ *
+ * Named queries are simply classes which implement a common query that we use
+ * regularly in the metadata. Things like "LatestProgrammes" or "PopularClips". By
+ * placing them in these queries, we can invisibly swap the implementations should
+ * we change the backend service etc.
+ *
+ * @package     BBC\iPlayerRadio\WebserviceKit
+ * @author      Alex Gisby <alex.gisby@bbc.co.uk>
+ * @copyright   BBC
+ */
+interface NamedQueryInterface
+{
+    /**
+     * Returns the query to execute against a WebserviceKit\Service instance.
+     *
+     * @return  \BBC\iPlayerRadio\WebserviceKit\QueryInterface|\BBC\iPlayerRadio\WebserviceKit\QueryInterface[]
+     */
+    public function query();
+
+    /**
+     * Allows the NamedQuery to perform any additional processing on the result
+     * before returning it.
+     *
+     * @param   mixed $results
+     * @return  mixed
+     */
+    public function processResults($results);
+}

--- a/src/PHPUnit/LoadMockedResponse.php
+++ b/src/PHPUnit/LoadMockedResponse.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace BBC\iPlayerRadio\WebserviceKit\PHPUnit;
+
+/**
+ * @codeCoverageIgnore
+ */
+trait LoadMockedResponse
+{
+    /**
+     * @param   string  $filename
+     * @return  string
+     */
+    protected function loadMockedResponse($filename)
+    {
+        $responsesDir = __DIR__.'/../../tests/mock_responses/';
+        if (!file_exists($responsesDir.$filename)) {
+            throw new \InvalidArgumentException('Unknown mocked response "'.$filename.'"');
+        }
+        return file_get_contents($responsesDir.$filename);
+    }
+}

--- a/src/Stubs/FindProgramme.php
+++ b/src/Stubs/FindProgramme.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace BBC\iPlayerRadio\WebserviceKit\Stubs;
+
+use BBC\iPlayerRadio\WebserviceKit\NamedQueryInterface;
+
+class FindProgramme implements NamedQueryInterface
+{
+    protected $pid;
+
+    public function __construct($pid)
+    {
+        $this->pid = $pid;
+    }
+
+    /**
+     * Returns the query to execute against a WebserviceKit\Service instance.
+     *
+     * @return  \BBC\iPlayerRadio\WebserviceKit\QueryInterface
+     */
+    public function query()
+    {
+        return (new ProgrammesQuery())
+            ->setPid($this->pid);
+    }
+
+    /**
+     * Allows the NamedQuery to perform any additional processing on the result
+     * before returning it.
+     *
+     * @param   mixed $results
+     * @return  mixed
+     */
+    public function processResults($results)
+    {
+        return $results;
+    }
+}

--- a/src/Stubs/FindProgrammes.php
+++ b/src/Stubs/FindProgrammes.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace BBC\iPlayerRadio\WebserviceKit\Stubs;
+
+use BBC\iPlayerRadio\WebserviceKit\NamedQueryInterface;
+
+class FindProgrammes implements NamedQueryInterface
+{
+    protected $pids = [];
+
+    public function __construct(array $pids)
+    {
+        $this->pids = $pids;
+    }
+
+    /**
+     * Returns the query to execute against a WebserviceKit\Service instance.
+     *
+     * @return  \BBC\iPlayerRadio\WebserviceKit\QueryInterface
+     */
+    public function query()
+    {
+        $queries = [];
+        foreach ($this->pids as $pid) {
+            $queries[] = (new ProgrammesQuery())->setPid($pid);
+        }
+        return $queries;
+    }
+
+    /**
+     * Allows the NamedQuery to perform any additional processing on the result
+     * before returning it.
+     *
+     * @param   mixed $results
+     * @return  mixed
+     */
+    public function processResults($results)
+    {
+        return $results;
+    }
+}

--- a/src/Stubs/ProgrammesQuery.php
+++ b/src/Stubs/ProgrammesQuery.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace BBC\iPlayerRadio\WebserviceKit\Stubs;
+
+class ProgrammesQuery extends Query
+{
+    public function setPid($pid)
+    {
+        return $this->setParameter('pid', $pid);
+    }
+
+    /**
+     * Returns the URL to query, with any parameters applied.
+     *
+     * @return  string
+     */
+    public function getURL()
+    {
+        return 'http://example.com/programmes.json?'.http_build_query($this->params);
+    }
+
+    /**
+     * Returns a friendly (and safe) name of the webservice this query hits which we can use in
+     * error logging and circuit breakers etc. [a-z0-9-_] please.
+     */
+    public function getServiceName()
+    {
+        return 'mock-programmes';
+    }
+}

--- a/src/WebserviceKitResolverBackend.php
+++ b/src/WebserviceKitResolverBackend.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace BBC\iPlayerRadio\WebserviceKit;
+
+use BBC\iPlayerRadio\Resolver\ResolverBackend;
+
+/**
+ * Class WebserviceKitResolverBackend
+ *
+ * This class provides a backend for the BBC\iPlayerRadio\Resolver package,
+ * allowing you to use WebserviceKit queries as requirements to the resolver.
+ *
+ * @package     BBC\iPlayerRadio\WebserviceKit
+ * @author      Alex Gisby <alex.gisby@bbc.co.uk>
+ * @copyright   BBC
+ */
+class WebserviceKitResolverBackend implements ResolverBackend
+{
+    /**
+     * @var     Service
+     */
+    protected $service;
+
+    /**
+     * @param   ServiceInterface     $service
+     */
+    public function __construct(ServiceInterface $service)
+    {
+        $this->service = $service;
+    }
+
+    /**
+     * @return  Service
+     */
+    public function getService()
+    {
+        return $this->service;
+    }
+
+    /**
+     * @param   Service     $service
+     * @return  $this
+     */
+    public function setService(Service $service)
+    {
+        $this->service = $service;
+        return $this;
+    }
+
+    /**
+     * Returns whether this backend can handle a given Requirement. Requirements
+     * can be absolutely anything, so make sure to verify correctly against it.
+     *
+     * @param   mixed $requirement
+     * @return  bool
+     */
+    public function canResolve($requirement)
+    {
+        if ($requirement instanceof QueryInterface || $requirement instanceof NamedQueryInterface) {
+            return true;
+        }
+
+        // If it's an array, loop and check:
+        if (is_array($requirement)) {
+            foreach ($requirement as $req) {
+                if ($req instanceof QueryInterface === false && $req instanceof NamedQueryInterface === false) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Given a list of requirements, perform their resolutions. Requirements can
+     * be absolutely anything from strings to full-bore objects.
+     *
+     * @param   array $requirements
+     * @return  array
+     */
+    public function doResolve(array $requirements)
+    {
+        return $this->service->fetch($requirements);
+    }
+}

--- a/tests/DataCollector/GuzzleDataCollectorTest.php
+++ b/tests/DataCollector/GuzzleDataCollectorTest.php
@@ -197,7 +197,6 @@ class GuzzleDataCollectorTest extends TestCase
         $this->assertEquals(202, $crawler->filter('.guzzle-request-connecttime')->first()->text());
         $this->assertEquals(1024, $crawler->filter('.guzzle-request-sizedownload')->first()->text());
         $this->assertEquals(24, $crawler->filter('.guzzle-request-speeddownload')->first()->text());
-        $this->assertCount(1, $crawler->filter('.guzzle-request-cachekey'));
     }
 
     public function testRenderMultipleRequests()

--- a/tests/WebserviceKitResolverBackendTest.php
+++ b/tests/WebserviceKitResolverBackendTest.php
@@ -1,0 +1,535 @@
+<?php
+
+namespace BBC\iPlayerRadio\WebserviceKit\Tests;
+
+use BBC\iPlayerRadio\WebserviceKit\NamedQueryInterface;
+use BBC\iPlayerRadio\WebserviceKit\PHPUnit\GetMockedService;
+use BBC\iPlayerRadio\WebserviceKit\PHPUnit\LoadMockedResponse;
+use BBC\iPlayerRadio\WebserviceKit\PHPUnit\TestCase;
+use BBC\iPlayerRadio\WebserviceKit\QueryInterface;
+use BBC\iPlayerRadio\WebserviceKit\Service;
+use BBC\iPlayerRadio\WebserviceKit\Stubs\FindProgramme;
+use BBC\iPlayerRadio\WebserviceKit\Stubs\FindProgrammes;
+use BBC\iPlayerRadio\WebserviceKit\Stubs\Monitoring;
+use BBC\iPlayerRadio\WebserviceKit\Stubs\ProgrammesQuery;
+use BBC\iPlayerRadio\WebserviceKit\Stubs\Query;
+use BBC\iPlayerRadio\WebserviceKit\WebserviceKitResolverBackend;
+use GuzzleHttp\Psr7\Response;
+
+class ResolverBackendTest extends TestCase
+{
+    use GetMockedService;
+    use LoadMockedResponse;
+
+    protected function preloadCache(Service $service, QueryInterface $query, $cacheData)
+    {
+        $service
+            ->getCache()
+            ->getAdapter()
+            ->save($query->getCacheKey(), $cacheData);
+    }
+
+    /* --------------- Get / Set Tests ---------------------- */
+
+    public function testGetSetService()
+    {
+        $service = $this->getMockedService();
+        $backend = new WebserviceKitResolverBackend($service);
+        $this->assertEquals($service, $backend->getService());
+
+        $newService = $this->getMockedService();
+        $newService->mark = 'green'; // this is to force PHP to copy the object.
+        $this->assertEquals($backend, $backend->setService($newService));
+        $this->assertNotEquals($service, $backend->getService());
+        $this->assertEquals($newService, $backend->getService());
+    }
+
+    /* -------------- canResolve() tests ---------------------- */
+
+    public function testCanResolvePureQuery()
+    {
+        $service = $this->getMockedService();
+
+        $backend = new WebserviceKitResolverBackend($service);
+        $query = new Query();
+
+        $this->assertTrue($backend->canResolve($query));
+    }
+
+    public function testCanResolveNamedQuery()
+    {
+        $service = $this->getMockedService();
+
+        $backend = new WebserviceKitResolverBackend($service);
+        $query = new Query();
+
+        $namedQuery = $this->getMockForAbstractClass(NamedQueryInterface::class);
+        $namedQuery
+            ->method('query')
+            ->willReturn($query);
+
+        $this->assertTrue($backend->canResolve($namedQuery));
+    }
+
+    public function testCanResolveArrayRequirements()
+    {
+        $service = $this->getMockedService();
+        $backend = new WebserviceKitResolverBackend($service);
+
+        $query1 = (new ProgrammesQuery())->setPid('testpid0');
+        $query2 = (new ProgrammesQuery())->setPid('testpid1');
+        $query3 = (new ProgrammesQuery())->setPid('testpid2');
+
+        $this->assertTrue($backend->canResolve([$query1, $query2, $query3]));
+    }
+
+    public function testCanResolveArrayRequirementsFails()
+    {
+        $service = $this->getMockedService();
+        $backend = new WebserviceKitResolverBackend($service);
+
+        $query1 = (new ProgrammesQuery())->setPid('testpid');
+        $query2 = 'Uh-oh';
+        $query3 = (new ProgrammesQuery())->setPid('testpid2');
+
+        $this->assertFalse($backend->canResolve([$query1, $query2, $query3]));
+    }
+
+    public function testCanResolveNonObjectRequirements()
+    {
+        $service = $this->getMockedService();
+
+        $backend = new WebserviceKitResolverBackend($service);
+
+        $this->assertFalse($backend->canResolve('unknown'));
+        $this->assertFalse($backend->canResolve(27));
+        $this->assertFalse($backend->canResolve(null));
+        $this->assertFalse($backend->canResolve(false));
+        $this->assertFalse($backend->canResolve(true));
+    }
+
+    /* ------------------ doResolve() tests -------------------- */
+
+    public function testDoResolveSingleQuery()
+    {
+        $service = $this->getMockedService([
+            $this->loadMockedResponse('result1.json')
+        ]);
+
+        $backend = new WebserviceKitResolverBackend($service);
+        $query = (new ProgrammesQuery())->setPid('testpid');
+
+        $result = $backend->doResolve([$query])[0];
+
+        $this->assertInstanceOf(\stdClass::class, $result);
+        $this->assertEquals('b006qpgr', $result->pid);
+    }
+
+    public function testDoResolveMultipleQueries()
+    {
+        $service = $this->getMockedService([
+            $this->loadMockedResponse('result1.json'),
+            $this->loadMockedResponse('result2.json')
+        ]);
+
+        $backend = new WebserviceKitResolverBackend($service);
+        $query1 = (new ProgrammesQuery())->setPid('testpid');
+        $query2 = (new ProgrammesQuery())->setPid('testpid2');
+
+        $result = $backend->doResolve([$query1, $query2]);
+
+        $this->assertCount(2, $result);
+
+        $this->assertInstanceOf(\stdClass::class, $result[0]);
+        $this->assertEquals('b006qpgr', $result[0]->pid);
+
+        $this->assertInstanceOf(\stdClass::class, $result[1]);
+        $this->assertEquals('b00snr0w', $result[1]->pid);
+    }
+
+    public function testDoResolveSingleFailedQuery()
+    {
+        $service = $this->getMockedService([new Response(500)]);
+
+        $backend = new WebserviceKitResolverBackend($service);
+        $query = (new ProgrammesQuery())->setPid('testpid');
+
+        $result = $backend->doResolve([$query]);
+        $this->assertCount(1, $result);
+        $this->assertFalse($result[0]);
+    }
+
+    public function testDoResolveMultipleFailedQueries()
+    {
+        $service = $this->getMockedService([
+            new Response(500),
+            new Response(500)
+        ]);
+
+        $backend = new WebserviceKitResolverBackend($service);
+        $query1 = (new ProgrammesQuery())->setPid('testpid');
+        $query2 = (new ProgrammesQuery())->setPid('testpid2');
+
+        $result = $backend->doResolve([$query1, $query2]);
+
+        $this->assertCount(2, $result);
+        $this->assertFalse($result[0]);
+        $this->assertFalse($result[1]);
+    }
+
+    public function testDoResolveSandwichedFailure()
+    {
+        $service = $this->getMockedService([
+            $this->loadMockedResponse('result1.json'),
+            new Response(500),
+            $this->loadMockedResponse('result2.json'),
+        ]);
+
+        $backend = new WebserviceKitResolverBackend($service);
+        $query1 = (new ProgrammesQuery())->setPid('testpid');
+        $query2 = (new ProgrammesQuery())->setPid('testpid1');
+        $query3 = (new ProgrammesQuery())->setPid('testpid2');
+
+        $result = $backend->doResolve([$query1, $query2, $query3]);
+
+        $this->assertCount(3, $result);
+
+        $this->assertInstanceOf(\stdClass::class, $result[0]);
+        $this->assertEquals('b006qpgr', $result[0]->pid);
+
+        $this->assertFalse($result[1]);
+
+        $this->assertInstanceOf(\stdClass::class, $result[2]);
+        $this->assertEquals('b00snr0w', $result[2]->pid);
+    }
+
+    public function testDoResolveAllCached()
+    {
+        $service = $this->getMockedService([new Response(500), new Response(500), new Response(500)]);
+
+        $query1 = (new ProgrammesQuery())->setPid('testpid');
+        $query2 = (new ProgrammesQuery())->setPid('testpid1');
+        $query3 = (new ProgrammesQuery())->setPid('testpid2');
+
+        // Pre-load the cache:
+        /* @var     \Doctrine\Common\Cache\ArrayCache   $cache  */
+        $this->preloadCache($service, $query1, [
+            'bestBefore'    => 10,
+            'storedTime'    => time(),
+            'payload'       => ['body' => $this->loadMockedResponse('result1.json'), 'headers' => []]
+        ]);
+        $this->preloadCache($service, $query2, [
+            'bestBefore'    => 10,
+            'storedTime'    => time(),
+            'payload'       => [
+                'body' => $this->loadMockedResponse('result2.json'), 'headers' => []
+            ]
+        ]);
+        $this->preloadCache($service, $query3, [
+            'bestBefore'    => 10,
+            'storedTime'    => time(),
+            'payload'       => ['body' => $this->loadMockedResponse('result3.json'), 'headers' => []]
+        ]);
+
+
+        $backend = new WebserviceKitResolverBackend($service);
+        $result = $backend->doResolve([$query1, $query2, $query3]);
+
+        $this->assertCount(3, $result);
+
+        $this->assertInstanceOf(\stdClass::class, $result[0]);
+        $this->assertEquals('b006qpgr', $result[0]->pid);
+
+        $this->assertInstanceOf(\stdClass::class, $result[1]);
+        $this->assertEquals('b00snr0w', $result[1]->pid);
+
+        $this->assertInstanceOf(\stdClass::class, $result[2]);
+        $this->assertEquals('b006wq4s', $result[2]->pid);
+    }
+
+    public function testDoResolveFirstNeedsFetch()
+    {
+        $service = $this->getMockedService([
+            $this->loadMockedResponse('result1.json'),
+        ]);
+
+        $query1 = (new ProgrammesQuery())->setPid('testpid');
+        $query2 = (new ProgrammesQuery())->setPid('testpid1');
+        $query3 = (new ProgrammesQuery())->setPid('testpid2');
+
+        // Pre-load the cache:
+        /* @var     \Doctrine\Common\Cache\ArrayCache   $cache  */
+        $this->preloadCache($service, $query2, [
+            'bestBefore'    => 10,
+            'storedTime'    => time(),
+            'payload'       => [
+                'body' => $this->loadMockedResponse('result2.json'), 'headers' => []
+            ]
+        ]);
+        $this->preloadCache($service, $query3, [
+            'bestBefore'    => 10,
+            'storedTime'    => time(),
+            'payload'       => ['body' => $this->loadMockedResponse('result3.json'), 'headers' => []]
+        ]);
+
+
+        $backend = new WebserviceKitResolverBackend($service);
+        $result = $backend->doResolve([$query1, $query2, $query3]);
+
+        $this->assertCount(3, $result);
+
+        $this->assertInstanceOf(\stdClass::class, $result[0]);
+        $this->assertEquals('b006qpgr', $result[0]->pid);
+
+        $this->assertInstanceOf(\stdClass::class, $result[1]);
+        $this->assertEquals('b00snr0w', $result[1]->pid);
+
+        $this->assertInstanceOf(\stdClass::class, $result[2]);
+        $this->assertEquals('b006wq4s', $result[2]->pid);
+    }
+
+    public function testDoResolveSecondNeedsFetch()
+    {
+        $service = $this->getMockedService([
+            $this->loadMockedResponse('result2.json'),
+        ]);
+
+        $query1 = (new ProgrammesQuery())->setPid('testpid');
+        $query2 = (new ProgrammesQuery())->setPid('testpid1');
+        $query3 = (new ProgrammesQuery())->setPid('testpid2');
+
+        // Pre-load the cache:
+        /* @var     \Doctrine\Common\Cache\ArrayCache   $cache  */
+        $this->preloadCache($service, $query1, [
+            'bestBefore'    => 10,
+            'storedTime'    => time(),
+            'payload'       => ['body' => $this->loadMockedResponse('result1.json'), 'headers' => []]
+        ]);
+        $this->preloadCache($service, $query3, [
+            'bestBefore'    => 10,
+            'storedTime'    => time(),
+            'payload'       => ['body' => $this->loadMockedResponse('result3.json'), 'headers' => []]
+        ]);
+
+
+        $backend = new WebserviceKitResolverBackend($service);
+        $result = $backend->doResolve([$query1, $query2, $query3]);
+
+        $this->assertCount(3, $result);
+
+        $this->assertInstanceOf(\stdClass::class, $result[0]);
+        $this->assertEquals('b006qpgr', $result[0]->pid);
+
+        $this->assertInstanceOf(\stdClass::class, $result[1]);
+        $this->assertEquals('b00snr0w', $result[1]->pid);
+
+        $this->assertInstanceOf(\stdClass::class, $result[2]);
+        $this->assertEquals('b006wq4s', $result[2]->pid);
+    }
+
+    public function testDoResolveThirdNeedsFetch()
+    {
+        $service = $this->getMockedService([
+            $this->loadMockedResponse('result3.json'),
+        ]);
+
+        $query1 = (new ProgrammesQuery())->setPid('testpid');
+        $query2 = (new ProgrammesQuery())->setPid('testpid1');
+        $query3 = (new ProgrammesQuery())->setPid('testpid2');
+
+        // Pre-load the cache:
+        /* @var     \Doctrine\Common\Cache\ArrayCache   $cache  */
+        $this->preloadCache($service, $query1, [
+            'bestBefore'    => 10,
+            'storedTime'    => time(),
+            'payload'       => ['body' => $this->loadMockedResponse('result1.json'), 'headers' => []]
+        ]);
+        $this->preloadCache($service, $query2, [
+            'bestBefore'    => 10,
+            'storedTime'    => time(),
+            'payload'       => [
+                'body' => $this->loadMockedResponse('result2.json'), 'headers' => []
+            ]
+        ]);
+
+
+        $backend = new WebserviceKitResolverBackend($service);
+        $result = $backend->doResolve([$query1, $query2, $query3]);
+
+        $this->assertCount(3, $result);
+
+        $this->assertInstanceOf(\stdClass::class, $result[0]);
+        $this->assertEquals('b006qpgr', $result[0]->pid);
+
+        $this->assertInstanceOf(\stdClass::class, $result[1]);
+        $this->assertEquals('b00snr0w', $result[1]->pid);
+
+        $this->assertInstanceOf(\stdClass::class, $result[2]);
+        $this->assertEquals('b006wq4s', $result[2]->pid);
+    }
+
+    public function testDoResolveSandwich()
+    {
+        $service = $this->getMockedService([
+            $this->loadMockedResponse('result1.json'),
+            $this->loadMockedResponse('result3.json'),
+        ]);
+
+        $query1 = (new ProgrammesQuery())->setPid('testpid');
+        $query2 = (new ProgrammesQuery())->setPid('testpid1');
+        $query3 = (new ProgrammesQuery())->setPid('testpid2');
+
+        // Pre-load the cache:
+        /* @var     \Doctrine\Common\Cache\ArrayCache   $cache  */
+        $this->preloadCache($service, $query2, [
+            'bestBefore'    => 10,
+            'storedTime'    => time(),
+            'payload'       => [
+                'body' => $this->loadMockedResponse('result2.json'), 'headers' => []
+            ]
+        ]);
+
+
+        $backend = new WebserviceKitResolverBackend($service);
+        $result = $backend->doResolve([$query1, $query2, $query3]);
+
+        $this->assertCount(3, $result);
+
+        $this->assertInstanceOf(\stdClass::class, $result[0]);
+        $this->assertEquals('b006qpgr', $result[0]->pid);
+
+        $this->assertInstanceOf(\stdClass::class, $result[1]);
+        $this->assertEquals('b00snr0w', $result[1]->pid);
+
+        $this->assertInstanceOf(\stdClass::class, $result[2]);
+        $this->assertEquals('b006wq4s', $result[2]->pid);
+    }
+
+    public function testDoResolveNamedQuery()
+    {
+        $service = $this->getMockedService([
+            $this->loadMockedResponse('result1.json')
+        ]);
+
+        $backend = new WebserviceKitResolverBackend($service);
+        $query = new FindProgramme('episodePid');
+
+        // processResults has been called and returned a single item.
+        $result = $backend->doResolve([$query])[0];
+        $this->assertInstanceOf(\stdClass::class, $result);
+        $this->assertEquals('b006qpgr', $result->pid);
+    }
+
+    /**
+     * Named queries can return an array of queries to run, which this test
+     * will ensure works:
+     */
+    public function testDoResolveQueryArray()
+    {
+        $service = $this->getMockedService([
+            $this->loadMockedResponse('result1.json'),
+            $this->loadMockedResponse('result2.json')
+        ]);
+
+        $q = new FindProgrammes(['b006qpgr', 'b00snr0w']);
+
+        $backend = new WebserviceKitResolverBackend($service);
+        $result = $backend->doResolve([$q])[0];
+
+        // the response should match the input format:
+        $this->assertInternalType('array', $result);
+        $this->assertCount(2, $result);
+
+        $this->assertInstanceOf(\stdClass::class, $result[0]);
+        $this->assertEquals('b006qpgr', $result[0]->pid);
+
+        $this->assertInstanceOf(\stdClass::class, $result[1]);
+        $this->assertEquals('b00snr0w', $result[1]->pid);
+    }
+
+    public function testDoResolveQueryArrayFailures()
+    {
+        $service = $this->getMockedService([
+            $this->loadMockedResponse('result1.json'),
+            500,
+            $this->loadMockedResponse('result3.json')
+        ]);
+
+        $q = new FindProgrammes(['b006qpgr', 'b00snr0w', 'b006wq4s']);
+
+        $backend = new WebserviceKitResolverBackend($service);
+        $result = $backend->doResolve([$q])[0];
+
+        // the response should match the input format:
+        $this->assertInternalType('array', $result);
+        $this->assertCount(3, $result);
+
+        $this->assertInstanceOf(\stdClass::class, $result[0]);
+        $this->assertEquals('b006qpgr', $result[0]->pid);
+
+        $this->assertFalse($result[1]);
+
+        $this->assertInstanceOf(\stdClass::class, $result[2]);
+        $this->assertEquals('b006wq4s', $result[2]->pid);
+    }
+
+    /* ------------- De-duplication tests -------------------- */
+
+    public function testDoResolveDuplicateQueries()
+    {
+        $service = $this->getMockedService([
+            $this->loadMockedResponse('result1.json'),
+        ]);
+
+        // Set the monitoring so we can track the number of queries.
+        $monitoring = new Monitoring();
+        $service->setMonitoring($monitoring);
+
+        $q1 = (new ProgrammesQuery())->setPid('b006qpgr');
+        $q2 = (new ProgrammesQuery())->setPid('b006qpgr');
+
+        $backend = new WebserviceKitResolverBackend($service);
+        $result = $backend->doResolve([$q1, $q2]);
+
+        $this->assertCount(2, $result);
+
+        $this->assertInstanceOf(\stdClass::class, $result[0]);
+        $this->assertEquals('b006qpgr', $result[0]->pid);
+        $this->assertInstanceOf(\stdClass::class, $result[1]);
+        $this->assertEquals('b006qpgr', $result[1]->pid);
+
+        // Ensure that only one request was made:
+        $this->assertEquals([
+            $q1->getServiceName() => 1
+        ], $monitoring->getApisCalled());
+    }
+
+    public function testDoResolveDuplicateNamedQueries()
+    {
+        $service = $this->getMockedService([
+            $this->loadMockedResponse('result1.json'),
+        ]);
+
+        // Set the monitoring so we can track the number of queries.
+        $monitoring = new Monitoring();
+        $service->setMonitoring($monitoring);
+
+        $q1 = new FindProgramme('b006qpgr');
+        $q2 = new FindProgramme('b006qpgr');
+
+        $backend = new WebserviceKitResolverBackend($service);
+        $result = $backend->doResolve([$q1, $q2]);
+
+        $this->assertCount(2, $result);
+
+        $this->assertInstanceOf(\stdClass::class, $result[0]);
+        $this->assertEquals('b006qpgr', $result[0]->pid);
+        $this->assertInstanceOf(\stdClass::class, $result[1]);
+        $this->assertEquals('b006qpgr', $result[1]->pid);
+
+        // Ensure that only one request was made:
+        $this->assertEquals([
+            'mock-programmes' => 1
+        ], $monitoring->getApisCalled());
+    }
+}

--- a/tests/mock_responses/result1.json
+++ b/tests/mock_responses/result1.json
@@ -1,0 +1,4 @@
+{
+    "pid": "b006qpgr",
+    "title": "The Archers"
+}

--- a/tests/mock_responses/result2.json
+++ b/tests/mock_responses/result2.json
@@ -1,0 +1,4 @@
+{
+    "pid": "b00snr0w",
+    "title": "The Infinite Monkey Cage"
+}

--- a/tests/mock_responses/result3.json
+++ b/tests/mock_responses/result3.json
@@ -1,0 +1,4 @@
+{
+    "pid": "b006wq4s",
+    "title": "Rock Show with Daniel P Carter"
+}

--- a/views/guzzle.html.twig
+++ b/views/guzzle.html.twig
@@ -109,7 +109,6 @@
                         <td class="guzzle-request-sizedownload">{{ r.size_download }}</td>
                         <td class="guzzle-request-speeddownload">{{ r.speed_download }}</td>
                     {% endif %}
-                    <td class="guzzle-request-cachekey">{{ r.cacheKey }}</td>
                 </tr>
                 <tr class="guzzle-request-additional">
                     <td colspan="7">


### PR DESCRIPTION
Three big new features added:

- **Named Queries**: we've been using named queries internally for a long time as a way of hiding the backend that data comes from. This promotes them to "first class citizens" in WebserviceKit allowing you to pass them to `fetch()` as if they were `QueryInterface` instances.
- **Resolver Backend**: We obviously use WSK in conjunction with the [Resolver](https://github.com/bbc/ipr-php-resolver) to do our metadata build, this PR hauls that code into the library main (and drastically simplifies it thanks to the changes supporting Named Queries)
- **De-duplication of queries**: before this PR, issuing the same query twice would result in two requests to the backend, resulting in some *hilarious* "72 queries for the same thing" scenarios on some of the metadata builds we do. WSK is now smart enough to notice this, and only issue the query once, but return as if it did it multiple times.

This has yielded a fairly large refactor (`fetch()` now handles a lot of admin, `doFetch()` actually does the work).

**No changes are required for clients! Everything will continue to work!**

- Fully unit tested.
- Fully code sniffed.
- Build passing.

@stephencoe @Jayflux @mgurgel @jucke @spa-simone - have at it.