### PR TITLE
Fixes to forceXXX functions + Cache-Control: no-cache.

### DIFF
--- a/docs/03-queries.md
+++ b/docs/03-queries.md
@@ -14,6 +14,8 @@ of your integration with the library.
     - [getSlowThreshold()](#getslowthreshold)
     - [Adaptive Timeouts](#adaptive-timeouts)
 - [Caching](#caching)
+    - [Overriding Cache Lifetimes](#overriding-cache-lifetimes)
+    - [Disabling Caching](#disabling-caching)
 - [Circuit Breakers](#circuit-breakers)
 - [isFailureState](#isFailureState)
 
@@ -437,9 +439,40 @@ If max-age is not defined in the headers, WebserviceKit will use `getMaxAge()` f
 
 If stale-while-revalidate is not defined in the headers, WebserviceKit will use `getStaleAge()` from the Query class.
 
-**Note**: it is not possible to override the Cache-Control header from a response! `getMaxAge` and `getStaleAge` are
-only called if the header values are not present. This is by design; APIs should be using these values to control their
-rate of request and clients should be good citizens.
+### Overriding Cache Lifetimes
+
+You *can* override cache lifetimes for individual queries, effectively asking WebserviceKit to ignore the response
+headers and use its own times. This is **strongly discouraged** since proper HTTP APIs should be returning correct
+Cache-Control headers (but we totally get that they often don't!).
+
+To override the stale and/or max ages, use the `forceXXX` functions:
+ 
+```php
+$query
+    ->forceMaxAge(1000)
+    ->forceStaleAge(100);
+```
+
+### Disabling Caching
+
+You can mark queries as never cacheable by returning `false` from the `QueryInterface::canCache` function:
+
+```php
+class MyNonCacheableQuery implements QueryInterface
+{
+    ...
+    
+    public function canCache()
+    {
+        return false;
+    }
+    
+    ...
+}
+```
+
+The Webservice itself can also disable caching by proving the `no-cache` directive in the `Cache-Control` header, which
+will be respected **unless** you also use `forceMaxAge()`.
 
 ## Circuit Breakers
 

--- a/src/QueryInterface.php
+++ b/src/QueryInterface.php
@@ -94,7 +94,7 @@ interface QueryInterface
      * Return the maximum age to keep the response cached. Note; Service will ignore this
      * value if the response has a max-age portion of the Cache-Control header
      *
-     * @return  int
+     * @return      int
      */
     public function getMaxAge();
 
@@ -102,7 +102,7 @@ interface QueryInterface
      * Return the age at which to consider a cached response stale. Note; WebserviceKit\Service will
      * ignore this value if the response has a stale-while-revalidate portion of it's Cache-Control header.
      *
-     * @return  int
+     * @return      int
      */
     public function getStaleAge();
 
@@ -113,6 +113,15 @@ interface QueryInterface
      * @return  bool
      */
     public function canCache();
+
+    /**
+     * Returns the stale and max lifetimes for the current query. Will be passed the cache control header
+     * coming back from the response.
+     *
+     * @param   string|null     $cacheControlHeader
+     * @return  array           [$staleAge, $maxAge]
+     */
+    public function getCacheAges($cacheControlHeader = null);
 
     /**
      * Returns the appropriate circuitbreaker to use for this query

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -17,13 +17,8 @@ class QueryTest extends TestCase
         $this->assertEquals(['connect_timeout' => 10, 'timeout' => 10], $query->getLongTimeouts());
         $this->assertEquals(60, $query->getStaleAge());
         $this->assertEquals(300, $query->getMaxAge());
-
-        $query->forceMaxAge(15);
-        $this->assertEquals(15, $query->getMaxAge());
-
-        $query->forceStaleAge(15);
-        $this->assertEquals(15, $query->getStaleAge());
-
+        $this->assertNull($query->getForcedMaxAge());
+        $this->assertNull($query->getForcedStaleAge());
         $this->assertTrue($query->isFailureState(new \Exception()));
         $this->assertEquals(md5($query->getURL()), $query->getCacheKey());
         $this->assertTrue($query->canCache());
@@ -62,6 +57,16 @@ class QueryTest extends TestCase
         $this->assertEquals('es-ES', $query->getParameter('lang', 'en-GB'));
     }
 
+    public function testForceMaxStale()
+    {
+        $query = new Query();
+        $this->assertEquals($query, $query->forceMaxAge(1000));
+        $this->assertEquals(1000, $query->getForcedMaxAge());
+
+        $this->assertEquals($query, $query->forceStaleAge(500));
+        $this->assertEquals(500, $query->getForcedStaleAge());
+    }
+
     public function testToString()
     {
         $query = new Query();
@@ -75,5 +80,135 @@ class QueryTest extends TestCase
         $this->assertEquals([], $query->getConfig());
         $this->assertEquals($query, $query->setConfig(['api_key' => 'some value']));
         $this->assertEquals(['api_key'=>'some value'], $query->getConfig());
+    }
+
+    /* ------------ Testing cache lifetime calculations ----------- */
+
+    public function testCacheAgesNoHeaders()
+    {
+        $query = new Query();
+        list($staleAge, $maxAge) = $query->getCacheAges();
+
+        $this->assertEquals(60, $staleAge);
+        $this->assertEquals(300, $maxAge);
+    }
+
+    public function testCacheAgesOnlyMax()
+    {
+        $query = new Query();
+        list($staleAge, $maxAge) = $query->getCacheAges('max-age=1000');
+
+        $this->assertEquals(60, $staleAge);
+        $this->assertEquals(1000, $maxAge);
+    }
+
+    public function testCacheAgesOnlyStale()
+    {
+        $query = new Query();
+        list($staleAge, $maxAge) = $query->getCacheAges('stale-while-revalidate=10');
+
+        $this->assertEquals(10, $staleAge);
+        $this->assertEquals(300, $maxAge);
+    }
+
+    public function testCacheAgesBoth()
+    {
+        $query = new Query();
+        list($staleAge, $maxAge) = $query->getCacheAges('max-age=1000,stale-while-revalidate=10');
+
+        $this->assertEquals(10, $staleAge);
+        $this->assertEquals(1000, $maxAge);
+    }
+
+    public function testCacheForcingNoHeaders()
+    {
+        $query = new Query();
+        $query
+            ->forceMaxAge(2000)
+            ->forceStaleAge(200);
+
+        list($staleAge, $maxAge) = $query->getCacheAges();
+
+        $this->assertEquals(200, $staleAge);
+        $this->assertEquals(2000, $maxAge);
+    }
+
+    public function testCacheForcingWithHeaders()
+    {
+        $query = new Query();
+        $query
+            ->forceMaxAge(2000)
+            ->forceStaleAge(200);
+
+        list($staleAge, $maxAge) = $query->getCacheAges('max-age=1000,stale-while-revalidate=10');
+
+        $this->assertEquals(200, $staleAge);
+        $this->assertEquals(2000, $maxAge);
+    }
+
+    public function testCacheForcingOnlyMax()
+    {
+        $query = new Query();
+        $query
+            ->forceMaxAge(2000);
+
+        list($staleAge, $maxAge) = $query->getCacheAges('max-age=1000,stale-while-revalidate=10');
+
+        $this->assertEquals(10, $staleAge);
+        $this->assertEquals(2000, $maxAge);
+
+        $query = new Query();
+        $query
+            ->forceMaxAge(2000)
+            ->forceStaleAge(200);
+
+        list($staleAge, $maxAge) = $query->getCacheAges('max-age=1000');
+
+        $this->assertEquals(200, $staleAge);
+        $this->assertEquals(2000, $maxAge);
+    }
+
+    public function testCacheForcingOnlyStale()
+    {
+        $query = new Query();
+        $query
+            ->forceStaleAge(200);
+
+        list($staleAge, $maxAge) = $query->getCacheAges('max-age=1000,stale-while-revalidate=10');
+
+        $this->assertEquals(200, $staleAge);
+        $this->assertEquals(1000, $maxAge);
+
+        $query = new Query();
+        $query
+            ->forceMaxAge(2000)
+            ->forceStaleAge(200);
+
+        list($staleAge, $maxAge) = $query->getCacheAges('stale-while-revalidate=1000');
+
+        $this->assertEquals(200, $staleAge);
+        $this->assertEquals(2000, $maxAge);
+    }
+
+    public function testNoCacheDirective()
+    {
+        $query = new Query();
+        list($staleAge, $maxAge) = $query->getCacheAges('no-cache,max-age=10,stale-while-validate=1');
+
+        $this->assertFalse($staleAge);
+        $this->assertFalse($maxAge);
+    }
+
+    public function testNoCacheWithForce()
+    {
+        $query = new Query();
+        $query
+            ->forceMaxAge(2000)
+            ->forceStaleAge(200);
+
+        list($staleAge, $maxAge) = $query->getCacheAges('no-cache,max-age=10,stale-while-validate=1');
+
+        $this->assertEquals(200, $staleAge);
+        $this->assertEquals(2000, $maxAge);
     }
 }


### PR DESCRIPTION
- Making forceXXXAge functions more aggressive
- Respecting no-cache from Webservices

This PR has moved the cache age calculations out of the Service class and into the Query class. The main reason for this is to make it more unit-testable since it's impossible to get the max-age value back out of the cache adapter. It also provides a hook for Query authors to totally ignore all the other stuff and return their own values!

`forceMaxAge` and `forceStaleAge` are now much more aggressive; ignoring everything in the Cache-Control header and doing their thing regardless.

At the other end, if the webservice replies `Cache-Control: no-cache`, WSK will respect that **unless** you have forced at least the max-age.

@stephencoe - this fixes what we were discussing this morning.