### PR TITLE
Adding a ResolverBackend implementation.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,10 @@
         "bbc/ipr-cache": "^1.0"
     },
     "require-dev": {
+        "bbc/ipr-resolver": "^0.2",
+        "silex/silex": "^2.0",
         "phpunit/phpunit": "^5.0",
         "squizlabs/php_codesniffer": "^2.0",
-        "silex/silex": "^2.0",
         "silex/web-profiler": "^2.0",
         "symfony/dom-crawler": "^3.0",
         "symfony/css-selector": "^3.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "1d24ee3715310549ee6ef7540212b133",
-    "content-hash": "1ee31ed3e1dd112659fa79116fd1a7b3",
+    "hash": "c2835e7040eca052556dcb59c21d3310",
+    "content-hash": "04bc42171f2b82cbe25b8e3f32ae99c5",
     "packages": [
         {
             "name": "bbc/ipr-cache",
-            "version": "v1.0.0",
+            "version": "v1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bbc/ipr-php-cache.git",
-                "reference": "dc9a3d6e3b7781990060657a7777bc5338356270"
+                "reference": "0d15d4b1f51c6d23918cc9a39960d042879ef4ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bbc/ipr-php-cache/zipball/dc9a3d6e3b7781990060657a7777bc5338356270",
-                "reference": "dc9a3d6e3b7781990060657a7777bc5338356270",
+                "url": "https://api.github.com/repos/bbc/ipr-php-cache/zipball/0d15d4b1f51c6d23918cc9a39960d042879ef4ac",
+                "reference": "0d15d4b1f51c6d23918cc9a39960d042879ef4ac",
                 "shasum": ""
             },
             "require": {
@@ -50,7 +50,7 @@
                 }
             ],
             "description": "A simple cache wrapper, making use of Doctrine Cache that implements fuzzy and stale-while-revalidate caching.",
-            "time": "2016-05-20 13:10:21"
+            "time": "2016-12-02 09:38:53"
         },
         {
             "name": "doctrine/cache",
@@ -186,16 +186,16 @@
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "1.2.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "c10d860e2a9595f8883527fa0021c7da9e65f579"
+                "reference": "2693c101803ca78b27972d84081d027fca790a1e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/c10d860e2a9595f8883527fa0021c7da9e65f579",
-                "reference": "c10d860e2a9595f8883527fa0021c7da9e65f579",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/2693c101803ca78b27972d84081d027fca790a1e",
+                "reference": "2693c101803ca78b27972d84081d027fca790a1e",
                 "shasum": ""
             },
             "require": {
@@ -233,7 +233,7 @@
             "keywords": [
                 "promise"
             ],
-            "time": "2016-05-18 16:56:05"
+            "time": "2016-11-18 17:47:58"
         },
         {
             "name": "guzzlehttp/psr7",
@@ -394,6 +394,46 @@
     ],
     "packages-dev": [
         {
+            "name": "bbc/ipr-resolver",
+            "version": "v0.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/bbc/ipr-php-resolver.git",
+                "reference": "0c4f5553e2a5dc1fbcd2fb64c8e8f42df96070ff"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/bbc/ipr-php-resolver/zipball/0c4f5553e2a5dc1fbcd2fb64c8e8f42df96070ff",
+                "reference": "0c4f5553e2a5dc1fbcd2fb64c8e8f42df96070ff",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0",
+                "squizlabs/php_codesniffer": "^2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "BBC\\iPlayerRadio\\Resolver\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alex Gisby",
+                    "email": "alex.gisby@bbc.co.uk"
+                }
+            ],
+            "description": "A dependency resolution library.",
+            "time": "2016-12-09 13:51:55"
+        },
+        {
             "name": "doctrine/instantiator",
             "version": "1.0.5",
             "source": {
@@ -488,6 +528,54 @@
                 "object graph"
             ],
             "time": "2016-10-31 17:19:45"
+        },
+        {
+            "name": "paragonie/random_compat",
+            "version": "v2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/random_compat.git",
+                "reference": "a9b97968bcde1c4de2a5ec6cbd06a0f6c919b46e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/a9b97968bcde1c4de2a5ec6cbd06a0f6c919b46e",
+                "reference": "a9b97968bcde1c4de2a5ec6cbd06a0f6c919b46e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*|5.*"
+            },
+            "suggest": {
+                "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/random.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com"
+                }
+            ],
+            "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
+            "keywords": [
+                "csprng",
+                "pseudorandom",
+                "random"
+            ],
+            "time": "2016-11-07 23:38:38"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -590,16 +678,16 @@
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "0.2",
+            "version": "0.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "b39c7a5b194f9ed7bd0dd345c751007a41862443"
+                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/b39c7a5b194f9ed7bd0dd345c751007a41862443",
-                "reference": "b39c7a5b194f9ed7bd0dd345c751007a41862443",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
+                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
                 "shasum": ""
             },
             "require": {
@@ -633,20 +721,20 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2016-06-10 07:14:17"
+            "time": "2016-11-25 06:54:22"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.6.1",
+            "version": "v1.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "58a8137754bc24b25740d4281399a4a3596058e0"
+                "reference": "6c52c2722f8460122f96f86346600e1077ce22cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/58a8137754bc24b25740d4281399a4a3596058e0",
-                "reference": "58a8137754bc24b25740d4281399a4a3596058e0",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/6c52c2722f8460122f96f86346600e1077ce22cb",
+                "reference": "6c52c2722f8460122f96f86346600e1077ce22cb",
                 "shasum": ""
             },
             "require": {
@@ -654,10 +742,11 @@
                 "php": "^5.3|^7.0",
                 "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
                 "sebastian/comparator": "^1.1",
-                "sebastian/recursion-context": "^1.0"
+                "sebastian/recursion-context": "^1.0|^2.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^2.0"
+                "phpspec/phpspec": "^2.0",
+                "phpunit/phpunit": "^4.8 || ^5.6.5"
             },
             "type": "library",
             "extra": {
@@ -695,20 +784,20 @@
                 "spy",
                 "stub"
             ],
-            "time": "2016-06-07 08:13:47"
+            "time": "2016-11-21 14:58:47"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "4.0.2",
+            "version": "4.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "6cba06ff75a1a63a71033e1a01b89056f3af1e8d"
+                "reference": "903fd6318d0a90b4770a009ff73e4a4e9c437929"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/6cba06ff75a1a63a71033e1a01b89056f3af1e8d",
-                "reference": "6cba06ff75a1a63a71033e1a01b89056f3af1e8d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/903fd6318d0a90b4770a009ff73e4a4e9c437929",
+                "reference": "903fd6318d0a90b4770a009ff73e4a4e9c437929",
                 "shasum": ""
             },
             "require": {
@@ -758,20 +847,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-11-01 05:06:24"
+            "time": "2016-11-28 16:00:31"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.1",
+            "version": "1.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0"
+                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
-                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
+                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
                 "shasum": ""
             },
             "require": {
@@ -805,7 +894,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2015-06-21 13:08:43"
+            "time": "2016-10-03 07:40:28"
         },
         {
             "name": "phpunit/php-text-template",
@@ -894,16 +983,16 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.8",
+            "version": "1.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da"
+                "reference": "3b402f65a4cc90abf6e1104e388b896ce209631b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
-                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/3b402f65a4cc90abf6e1104e388b896ce209631b",
+                "reference": "3b402f65a4cc90abf6e1104e388b896ce209631b",
                 "shasum": ""
             },
             "require": {
@@ -939,20 +1028,20 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2015-09-15 10:49:45"
+            "time": "2016-11-15 14:06:22"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "5.6.2",
+            "version": "5.7.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "cd13b23ac5a519a4708e00736c26ee0bb28b2e01"
+                "reference": "af91da3f2671006ff5d0628023de3b7ac4d1ef09"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/cd13b23ac5a519a4708e00736c26ee0bb28b2e01",
-                "reference": "cd13b23ac5a519a4708e00736c26ee0bb28b2e01",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/af91da3f2671006ff5d0628023de3b7ac4d1ef09",
+                "reference": "af91da3f2671006ff5d0628023de3b7ac4d1ef09",
                 "shasum": ""
             },
             "require": {
@@ -963,18 +1052,18 @@
                 "ext-xml": "*",
                 "myclabs/deep-copy": "~1.3",
                 "php": "^5.6 || ^7.0",
-                "phpspec/prophecy": "^1.3.1",
-                "phpunit/php-code-coverage": "^4.0.1",
+                "phpspec/prophecy": "^1.6.2",
+                "phpunit/php-code-coverage": "^4.0.3",
                 "phpunit/php-file-iterator": "~1.4",
                 "phpunit/php-text-template": "~1.2",
                 "phpunit/php-timer": "^1.0.6",
                 "phpunit/phpunit-mock-objects": "^3.2",
-                "sebastian/comparator": "~1.1",
+                "sebastian/comparator": "~1.2.2",
                 "sebastian/diff": "~1.2",
-                "sebastian/environment": "^1.3 || ^2.0",
-                "sebastian/exporter": "~1.2",
-                "sebastian/global-state": "~1.0",
-                "sebastian/object-enumerator": "~1.0",
+                "sebastian/environment": "^1.3.4 || ^2.0",
+                "sebastian/exporter": "~2.0",
+                "sebastian/global-state": "^1.0 || ^2.0",
+                "sebastian/object-enumerator": "~2.0",
                 "sebastian/resource-operations": "~1.0",
                 "sebastian/version": "~1.0|~2.0",
                 "symfony/yaml": "~2.1|~3.0"
@@ -995,7 +1084,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.6.x-dev"
+                    "dev-master": "5.7.x-dev"
                 }
             },
             "autoload": {
@@ -1021,27 +1110,27 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-10-25 07:40:25"
+            "time": "2016-12-13 16:19:44"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "3.4.0",
+            "version": "3.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "238d7a2723bce689c79eeac9c7d5e1d623bb9dc2"
+                "reference": "3ab72b65b39b491e0c011e2e09bb2206c2aa8e24"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/238d7a2723bce689c79eeac9c7d5e1d623bb9dc2",
-                "reference": "238d7a2723bce689c79eeac9c7d5e1d623bb9dc2",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/3ab72b65b39b491e0c011e2e09bb2206c2aa8e24",
+                "reference": "3ab72b65b39b491e0c011e2e09bb2206c2aa8e24",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.6 || ^7.0",
                 "phpunit/php-text-template": "^1.2",
-                "sebastian/exporter": "^1.2"
+                "sebastian/exporter": "^1.2 || ^2.0"
             },
             "conflict": {
                 "phpunit/phpunit": "<5.4.0"
@@ -1080,7 +1169,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2016-10-09 07:01:45"
+            "time": "2016-12-08 20:27:08"
         },
         {
             "name": "pimple/pimple",
@@ -1222,22 +1311,22 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "1.2.0",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22"
+                "reference": "6a1ed12e8b2409076ab22e3897126211ff8b1f7f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/937efb279bd37a375bcadf584dec0726f84dbf22",
-                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/6a1ed12e8b2409076ab22e3897126211ff8b1f7f",
+                "reference": "6a1ed12e8b2409076ab22e3897126211ff8b1f7f",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3",
                 "sebastian/diff": "~1.2",
-                "sebastian/exporter": "~1.2"
+                "sebastian/exporter": "~1.2 || ~2.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "~4.4"
@@ -1282,7 +1371,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2015-07-26 15:48:44"
+            "time": "2016-11-19 09:18:40"
         },
         {
             "name": "sebastian/diff",
@@ -1338,28 +1427,28 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "1.3.8",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea"
+                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/be2c607e43ce4c89ecd60e75c6a85c126e754aea",
-                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
+                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8 || ^5.0"
+                "phpunit/phpunit": "^5.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -1384,25 +1473,25 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-08-18 05:49:44"
+            "time": "2016-11-26 07:53:53"
         },
         {
             "name": "sebastian/exporter",
-            "version": "1.2.2",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4"
+                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/42c4c2eec485ee3e159ec9884f95b431287edde4",
-                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
+                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3",
-                "sebastian/recursion-context": "~1.0"
+                "sebastian/recursion-context": "~2.0"
             },
             "require-dev": {
                 "ext-mbstring": "*",
@@ -1411,7 +1500,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -1451,7 +1540,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-06-17 09:04:28"
+            "time": "2016-11-19 08:54:04"
         },
         {
             "name": "sebastian/global-state",
@@ -1506,21 +1595,21 @@
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "1.0.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "d4ca2fb70344987502567bc50081c03e6192fb26"
+                "reference": "96f8a3f257b69e8128ad74d3a7fd464bcbaa3b35"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/d4ca2fb70344987502567bc50081c03e6192fb26",
-                "reference": "d4ca2fb70344987502567bc50081c03e6192fb26",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/96f8a3f257b69e8128ad74d3a7fd464bcbaa3b35",
+                "reference": "96f8a3f257b69e8128ad74d3a7fd464bcbaa3b35",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.6",
-                "sebastian/recursion-context": "~1.0"
+                "sebastian/recursion-context": "~2.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "~5"
@@ -1528,7 +1617,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -1548,20 +1637,20 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2016-01-28 13:25:10"
+            "time": "2016-11-19 07:35:10"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "1.0.2",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "913401df809e99e4f47b27cdd781f4a258d58791"
+                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/913401df809e99e4f47b27cdd781f4a258d58791",
-                "reference": "913401df809e99e4f47b27cdd781f4a258d58791",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/2c3ba150cbec723aa057506e73a8d33bdb286c9a",
+                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a",
                 "shasum": ""
             },
             "require": {
@@ -1573,7 +1662,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -1601,7 +1690,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2015-11-11 19:50:13"
+            "time": "2016-11-19 07:33:16"
         },
         {
             "name": "sebastian/resource-operations",
@@ -1647,16 +1736,16 @@
         },
         {
             "name": "sebastian/version",
-            "version": "2.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "c829badbd8fdf16a0bad8aa7fa7971c029f1b9c5"
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c829badbd8fdf16a0bad8aa7fa7971c029f1b9c5",
-                "reference": "c829badbd8fdf16a0bad8aa7fa7971c029f1b9c5",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
                 "shasum": ""
             },
             "require": {
@@ -1686,7 +1775,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2016-02-04 12:56:52"
+            "time": "2016-10-03 07:35:21"
         },
         {
             "name": "silex/silex",
@@ -1775,17 +1864,17 @@
         },
         {
             "name": "silex/web-profiler",
-            "version": "v2.0.4",
+            "version": "v2.0.5",
             "target-dir": "Silex/Provider",
             "source": {
                 "type": "git",
                 "url": "https://github.com/silexphp/Silex-WebProfiler.git",
-                "reference": "db11b65f98939440d985042d8f76a7148af9155d"
+                "reference": "b44c4c8e70a43eb5e98372cffbeb6de3770c5805"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/silexphp/Silex-WebProfiler/zipball/db11b65f98939440d985042d8f76a7148af9155d",
-                "reference": "db11b65f98939440d985042d8f76a7148af9155d",
+                "url": "https://api.github.com/repos/silexphp/Silex-WebProfiler/zipball/b44c4c8e70a43eb5e98372cffbeb6de3770c5805",
+                "reference": "b44c4c8e70a43eb5e98372cffbeb6de3770c5805",
                 "shasum": ""
             },
             "require": {
@@ -1828,20 +1917,20 @@
             ],
             "description": "A WebProfiler for Silex",
             "homepage": "http://silex.sensiolabs.org/",
-            "time": "2016-10-27 01:28:31"
+            "time": "2016-11-21 23:51:53"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.7.0",
+            "version": "2.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "571e27b6348e5b3a637b2abc82ac0d01e6d7bbed"
+                "reference": "9b324f3a1132459a7274a0ace2e1b766ba80930f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/571e27b6348e5b3a637b2abc82ac0d01e6d7bbed",
-                "reference": "571e27b6348e5b3a637b2abc82ac0d01e6d7bbed",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/9b324f3a1132459a7274a0ace2e1b766ba80930f",
+                "reference": "9b324f3a1132459a7274a0ace2e1b766ba80930f",
                 "shasum": ""
             },
             "require": {
@@ -1906,20 +1995,20 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2016-09-01 23:53:02"
+            "time": "2016-11-30 04:02:31"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v3.1.6",
+            "version": "v3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "ca809c64072e0fe61c1c7fb3c76cdc32265042ac"
+                "reference": "e1241f275814827c411d922ba8e64cf2a00b2994"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/ca809c64072e0fe61c1c7fb3c76cdc32265042ac",
-                "reference": "ca809c64072e0fe61c1c7fb3c76cdc32265042ac",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/e1241f275814827c411d922ba8e64cf2a00b2994",
+                "reference": "e1241f275814827c411d922ba8e64cf2a00b2994",
                 "shasum": ""
             },
             "require": {
@@ -1928,7 +2017,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -1959,20 +2048,20 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-06 11:02:40"
+            "time": "2016-11-03 08:11:03"
         },
         {
             "name": "symfony/debug",
-            "version": "v3.1.6",
+            "version": "v3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "e2b3f74a67fc928adc3c1b9027f73e1bc01190a8"
+                "reference": "9f923e68d524a3095c5a2ae5fc7220c7cbc12231"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/e2b3f74a67fc928adc3c1b9027f73e1bc01190a8",
-                "reference": "e2b3f74a67fc928adc3c1b9027f73e1bc01190a8",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/9f923e68d524a3095c5a2ae5fc7220c7cbc12231",
+                "reference": "9f923e68d524a3095c5a2ae5fc7220c7cbc12231",
                 "shasum": ""
             },
             "require": {
@@ -1989,7 +2078,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -2016,20 +2105,20 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-06 11:02:40"
+            "time": "2016-11-16 22:18:16"
         },
         {
             "name": "symfony/dom-crawler",
-            "version": "v3.1.6",
+            "version": "v3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dom-crawler.git",
-                "reference": "59eee3c76eb89f21857798620ebdad7a05ad14f4"
+                "reference": "1638c7534a8a2fa0bf9e979f9aacb6d7e8e9e24e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/59eee3c76eb89f21857798620ebdad7a05ad14f4",
-                "reference": "59eee3c76eb89f21857798620ebdad7a05ad14f4",
+                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/1638c7534a8a2fa0bf9e979f9aacb6d7e8e9e24e",
+                "reference": "1638c7534a8a2fa0bf9e979f9aacb6d7e8e9e24e",
                 "shasum": ""
             },
             "require": {
@@ -2045,7 +2134,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -2072,20 +2161,20 @@
             ],
             "description": "Symfony DomCrawler Component",
             "homepage": "https://symfony.com",
-            "time": "2016-10-18 15:46:07"
+            "time": "2016-12-10 14:24:53"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v3.1.6",
+            "version": "v3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "28b0832b2553ffb80cabef6a7a812ff1e670c0bc"
+                "reference": "e8f47a327c2f0fd5aa04fa60af2b693006ed7283"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/28b0832b2553ffb80cabef6a7a812ff1e670c0bc",
-                "reference": "28b0832b2553ffb80cabef6a7a812ff1e670c0bc",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/e8f47a327c2f0fd5aa04fa60af2b693006ed7283",
+                "reference": "e8f47a327c2f0fd5aa04fa60af2b693006ed7283",
                 "shasum": ""
             },
             "require": {
@@ -2105,7 +2194,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -2132,20 +2221,20 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2016-10-13 06:28:43"
+            "time": "2016-10-13 06:29:04"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v3.1.6",
+            "version": "v3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "f21e5a8b88274b7720779aa88f9c02c6d6ec08d7"
+                "reference": "9963bc29d7f4398b137dd8efc480efe54fdbe5f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/f21e5a8b88274b7720779aa88f9c02c6d6ec08d7",
-                "reference": "f21e5a8b88274b7720779aa88f9c02c6d6ec08d7",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/9963bc29d7f4398b137dd8efc480efe54fdbe5f1",
+                "reference": "9963bc29d7f4398b137dd8efc480efe54fdbe5f1",
                 "shasum": ""
             },
             "require": {
@@ -2158,7 +2247,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -2185,20 +2274,20 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "time": "2016-10-24 15:52:44"
+            "time": "2016-11-27 04:21:38"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v3.1.6",
+            "version": "v3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "c235f1b13ba67012e283996a5427f22e2e04be14"
+                "reference": "8fedefadee9c91567414a07130c81e7c406fe68a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/c235f1b13ba67012e283996a5427f22e2e04be14",
-                "reference": "c235f1b13ba67012e283996a5427f22e2e04be14",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/8fedefadee9c91567414a07130c81e7c406fe68a",
+                "reference": "8fedefadee9c91567414a07130c81e7c406fe68a",
                 "shasum": ""
             },
             "require": {
@@ -2226,7 +2315,7 @@
                 "symfony/stopwatch": "~2.8|~3.0",
                 "symfony/templating": "~2.8|~3.0",
                 "symfony/translation": "~2.8|~3.0",
-                "symfony/var-dumper": "~2.8|~3.0"
+                "symfony/var-dumper": "~3.2"
             },
             "suggest": {
                 "symfony/browser-kit": "",
@@ -2240,7 +2329,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -2267,20 +2356,20 @@
             ],
             "description": "Symfony HttpKernel Component",
             "homepage": "https://symfony.com",
-            "time": "2016-10-27 02:38:31"
+            "time": "2016-12-13 13:19:46"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.2.0",
+            "version": "v1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "dff51f72b0706335131b00a7f49606168c582594"
+                "reference": "e79d363049d1c2128f133a2667e4f4190904f7f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/dff51f72b0706335131b00a7f49606168c582594",
-                "reference": "dff51f72b0706335131b00a7f49606168c582594",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/e79d363049d1c2128f133a2667e4f4190904f7f4",
+                "reference": "e79d363049d1c2128f133a2667e4f4190904f7f4",
                 "shasum": ""
             },
             "require": {
@@ -2292,7 +2381,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2-dev"
+                    "dev-master": "1.3-dev"
                 }
             },
             "autoload": {
@@ -2326,20 +2415,79 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-05-18 14:26:46"
+            "time": "2016-11-14 01:06:16"
         },
         {
-            "name": "symfony/routing",
-            "version": "v3.1.6",
+            "name": "symfony/polyfill-php70",
+            "version": "v1.3.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/routing.git",
-                "reference": "8edf62498a1a4c57ba317664a4b698339c10cdf6"
+                "url": "https://github.com/symfony/polyfill-php70.git",
+                "reference": "13ce343935f0f91ca89605a2f6ca6f5c2f3faac2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/8edf62498a1a4c57ba317664a4b698339c10cdf6",
-                "reference": "8edf62498a1a4c57ba317664a4b698339c10cdf6",
+                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/13ce343935f0f91ca89605a2f6ca6f5c2f3faac2",
+                "reference": "13ce343935f0f91ca89605a2f6ca6f5c2f3faac2",
+                "shasum": ""
+            },
+            "require": {
+                "paragonie/random_compat": "~1.0|~2.0",
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php70\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2016-11-14 01:06:16"
+        },
+        {
+            "name": "symfony/routing",
+            "version": "v3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/routing.git",
+                "reference": "3f239c0e049d8920928674cd55e21061182b0106"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/3f239c0e049d8920928674cd55e21061182b0106",
+                "reference": "3f239c0e049d8920928674cd55e21061182b0106",
                 "shasum": ""
             },
             "require": {
@@ -2368,7 +2516,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -2401,20 +2549,20 @@
                 "uri",
                 "url"
             ],
-            "time": "2016-08-16 14:58:24"
+            "time": "2016-11-25 12:32:42"
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v3.1.6",
+            "version": "v3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "bb42806b12c5f89db4ebf64af6741afe6d8457e1"
+                "reference": "5b139e1c4290e6c7640ba80d9c9b5e49ef22b841"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/bb42806b12c5f89db4ebf64af6741afe6d8457e1",
-                "reference": "bb42806b12c5f89db4ebf64af6741afe6d8457e1",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/5b139e1c4290e6c7640ba80d9c9b5e49ef22b841",
+                "reference": "5b139e1c4290e6c7640ba80d9c9b5e49ef22b841",
                 "shasum": ""
             },
             "require": {
@@ -2423,7 +2571,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -2450,25 +2598,25 @@
             ],
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 05:41:56"
+            "time": "2016-06-29 05:43:10"
         },
         {
             "name": "symfony/twig-bridge",
-            "version": "v3.1.6",
+            "version": "v3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/twig-bridge.git",
-                "reference": "a75dfd56d7cf8df1843dcf44a0d6d4ef8b72440c"
+                "reference": "f6d8339d7b8b1d71b60eb13888d5db53acb868ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/twig-bridge/zipball/a75dfd56d7cf8df1843dcf44a0d6d4ef8b72440c",
-                "reference": "a75dfd56d7cf8df1843dcf44a0d6d4ef8b72440c",
+                "url": "https://api.github.com/repos/symfony/twig-bridge/zipball/f6d8339d7b8b1d71b60eb13888d5db53acb868ac",
+                "reference": "f6d8339d7b8b1d71b60eb13888d5db53acb868ac",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.5.9",
-                "twig/twig": "~1.27|~2.0"
+                "twig/twig": "~1.28|~2.0"
             },
             "require-dev": {
                 "symfony/asset": "~2.8|~3.0",
@@ -2476,7 +2624,7 @@
                 "symfony/expression-language": "~2.8|~3.0",
                 "symfony/finder": "~2.8|~3.0",
                 "symfony/form": "~3.0.4",
-                "symfony/http-kernel": "~2.8|~3.0",
+                "symfony/http-kernel": "~3.2",
                 "symfony/polyfill-intl-icu": "~1.0",
                 "symfony/routing": "~2.8|~3.0",
                 "symfony/security": "~2.8|~3.0",
@@ -2484,7 +2632,7 @@
                 "symfony/stopwatch": "~2.8|~3.0",
                 "symfony/templating": "~2.8|~3.0",
                 "symfony/translation": "~2.8|~3.0",
-                "symfony/var-dumper": "~2.8.9|~3.0.9|~3.1.3|~3.2",
+                "symfony/var-dumper": "~2.8.10|~3.1.4|~3.2",
                 "symfony/yaml": "~2.8|~3.0"
             },
             "suggest": {
@@ -2504,7 +2652,7 @@
             "type": "symfony-bridge",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -2531,27 +2679,96 @@
             ],
             "description": "Symfony Twig Bridge",
             "homepage": "https://symfony.com",
-            "time": "2016-10-24 15:52:44"
+            "time": "2016-12-12 19:31:24"
         },
         {
-            "name": "symfony/web-profiler-bundle",
-            "version": "v3.1.6",
+            "name": "symfony/var-dumper",
+            "version": "v3.2.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/web-profiler-bundle.git",
-                "reference": "051d666ab2a9ddb48fb9283d8b940aba055a6a84"
+                "url": "https://github.com/symfony/var-dumper.git",
+                "reference": "f722532b0966e9b6fc631e682143c07b2cf583a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/web-profiler-bundle/zipball/051d666ab2a9ddb48fb9283d8b940aba055a6a84",
-                "reference": "051d666ab2a9ddb48fb9283d8b940aba055a6a84",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/f722532b0966e9b6fc631e682143c07b2cf583a0",
+                "reference": "f722532b0966e9b6fc631e682143c07b2cf583a0",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.5.9",
-                "symfony/http-kernel": "~3.1",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "require-dev": {
+                "twig/twig": "~1.20|~2.0"
+            },
+            "suggest": {
+                "ext-symfony_debug": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "Resources/functions/dump.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\VarDumper\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony mechanism for exploring and dumping PHP variables",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "debug",
+                "dump"
+            ],
+            "time": "2016-12-11 14:34:22"
+        },
+        {
+            "name": "symfony/web-profiler-bundle",
+            "version": "v3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/web-profiler-bundle.git",
+                "reference": "2508f7ceadbdda65b0495a4e676bde664bb2628b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/web-profiler-bundle/zipball/2508f7ceadbdda65b0495a4e676bde664bb2628b",
+                "reference": "2508f7ceadbdda65b0495a4e676bde664bb2628b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9",
+                "symfony/http-kernel": "~3.2",
+                "symfony/polyfill-php70": "~1.0",
                 "symfony/routing": "~2.8|~3.0",
-                "symfony/twig-bridge": "~2.8|~3.0"
+                "symfony/twig-bridge": "~2.8|~3.0",
+                "symfony/var-dumper": "~3.2",
+                "twig/twig": "~1.28|~2.0"
+            },
+            "conflict": {
+                "symfony/event-dispatcher": "<3.2"
             },
             "require-dev": {
                 "symfony/config": "~2.8|~3.0",
@@ -2562,7 +2779,7 @@
             "type": "symfony-bundle",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -2589,29 +2806,35 @@
             ],
             "description": "Symfony WebProfilerBundle",
             "homepage": "https://symfony.com",
-            "time": "2016-10-23 01:13:38"
+            "time": "2016-12-13 08:50:09"
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.1.6",
+            "version": "v3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "7ff51b06c6c3d5cc6686df69004a42c69df09e27"
+                "reference": "a7095af4b97a0955f85c8989106c249fa649011f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/7ff51b06c6c3d5cc6686df69004a42c69df09e27",
-                "reference": "7ff51b06c6c3d5cc6686df69004a42c69df09e27",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/a7095af4b97a0955f85c8989106c249fa649011f",
+                "reference": "a7095af4b97a0955f85c8989106c249fa649011f",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.5.9"
             },
+            "require-dev": {
+                "symfony/console": "~2.8|~3.0"
+            },
+            "suggest": {
+                "symfony/console": "For validating YAML files using the lint command"
+            },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -2638,20 +2861,20 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-10-24 18:41:13"
+            "time": "2016-12-10 10:07:06"
         },
         {
             "name": "twig/twig",
-            "version": "v1.27.0",
+            "version": "v1.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "3c6c0033fd3b5679c6e1cb60f4f9766c2b424d97"
+                "reference": "74f723e542368ca2080b252740be5f1113ebb898"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/3c6c0033fd3b5679c6e1cb60f4f9766c2b424d97",
-                "reference": "3c6c0033fd3b5679c6e1cb60f4f9766c2b424d97",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/74f723e542368ca2080b252740be5f1113ebb898",
+                "reference": "74f723e542368ca2080b252740be5f1113ebb898",
                 "shasum": ""
             },
             "require": {
@@ -2659,12 +2882,12 @@
             },
             "require-dev": {
                 "symfony/debug": "~2.7",
-                "symfony/phpunit-bridge": "~2.7"
+                "symfony/phpunit-bridge": "~3.2@dev"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.27-dev"
+                    "dev-master": "1.29-dev"
                 }
             },
             "autoload": {
@@ -2699,24 +2922,24 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2016-10-25 19:17:17"
+            "time": "2016-12-13 17:28:18"
         },
         {
             "name": "webmozart/assert",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "bb2d123231c095735130cc8f6d31385a44c7b308"
+                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/bb2d123231c095735130cc8f6d31385a44c7b308",
-                "reference": "bb2d123231c095735130cc8f6d31385a44c7b308",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3|^7.0"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.6",
@@ -2725,7 +2948,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2-dev"
+                    "dev-master": "1.3-dev"
                 }
             },
             "autoload": {
@@ -2749,7 +2972,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-08-09 15:02:57"
+            "time": "2016-11-23 20:04:58"
         }
     ],
     "aliases": [],

--- a/docs/00-intro.md
+++ b/docs/00-intro.md
@@ -23,3 +23,4 @@ to RESTful style APIs especially suited for Service Oriented Architectures.
 - [Fixtures](./04-fixtures.md)
 - [Monitoring](./05-monitoring.md)
 - [Profiler](./06-profiler.md)
+- [Resolver Backend](./07-resolver-backend.md)

--- a/docs/07-resolver-backend.md
+++ b/docs/07-resolver-backend.md
@@ -1,0 +1,51 @@
+# Resolver Backend
+
+*New in v1.1.0*
+
+If you're a user of the [BBC\iPlayerRadio\Resolver](https://github.com/bbc/ipr-php-resolver) library, you'll
+probably want to hook it up to WebserviceKit so that you can use queries as resolutions.
+
+WebserviceKit provides a Resolver Backend to do exactly that:
+
+```php
+// Create a service instance:
+$service = new \BBC\iPlayerRadio\WebserviceKit\Service(
+    new \GuzzleHttp\Client(),
+    new \BBC\iPlayerRadio\Cache\Cache(new \Doctrine\Common\Cache\RedisCache())
+);
+
+$resolver = new \BBC\iPlayerRadio\Resolver\Resolver();
+
+// Register the backend:
+$resolver->addBackend(
+    new \BBC\iPlayerRadio\WebserviceKit\WebserviceKitResolverBackend($service)
+);
+```
+
+You can now yield `QueryInterface` instances from your `requires` blocks:
+
+```php
+class ItemQuery extends \BBC\iPlayerRadio\WebserviceKit\Query
+{
+    // ...
+}
+
+class Article implements \BBC\iPlayerRadio\Resolver\HasRequirements
+{    
+    protected $id;
+    
+    public function __construct($id)
+    {
+        $this->id = $id;
+    }
+    
+    public function requires(array $flags = [])
+    {
+        $this->data = (yield new ItemQuery($this->id));  
+    }   
+}
+
+$article = new Article('my-id');
+$resolver->resolve($article);
+
+```

--- a/src/PHPUnit/LoadMockedResponse.php
+++ b/src/PHPUnit/LoadMockedResponse.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace BBC\iPlayerRadio\WebserviceKit\PHPUnit;
+
+/**
+ * @codeCoverageIgnore
+ */
+trait LoadMockedResponse
+{
+    /**
+     * @param   string  $filename
+     * @return  string
+     */
+    protected function loadMockedResponse($filename)
+    {
+        $responsesDir = __DIR__.'/../../tests/mock_responses/';
+        if (!file_exists($responsesDir.$filename)) {
+            throw new \InvalidArgumentException('Unknown mocked response "'.$filename.'"');
+        }
+        return file_get_contents($responsesDir.$filename);
+    }
+}

--- a/src/Stubs/ProgrammesQuery.php
+++ b/src/Stubs/ProgrammesQuery.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace BBC\iPlayerRadio\WebserviceKit\Stubs;
+
+class ProgrammesQuery extends Query
+{
+    public function setPid($pid)
+    {
+        return $this->setParameter('pid', $pid);
+    }
+
+    /**
+     * Returns the URL to query, with any parameters applied.
+     *
+     * @return  string
+     */
+    public function getURL()
+    {
+        return 'http://example.com/programmes.json?'.http_build_query($this->params);
+    }
+
+    /**
+     * Returns a friendly (and safe) name of the webservice this query hits which we can use in
+     * error logging and circuit breakers etc. [a-z0-9-_] please.
+     */
+    public function getServiceName()
+    {
+        return 'mock-programmes';
+    }
+}

--- a/src/WebserviceKitResolverBackend.php
+++ b/src/WebserviceKitResolverBackend.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace BBC\iPlayerRadio\WebserviceKit;
+
+use BBC\iPlayerRadio\Resolver\ResolverBackend;
+
+/**
+ * Class WebserviceKitResolverBackend
+ *
+ * This class provides a ResolverBackend implementation allowing you to use
+ * WebserviceKit requests wit the bbc/ipr-resolver library.
+ *
+ * @package     BBC\iPlayerRadio\WebserviceKit
+ * @author      Alex Gisby <alex.gisby@bbc.co.uk>
+ * @copyright   BBC
+ */
+class WebserviceKitResolverBackend implements ResolverBackend
+{
+    /**
+     * @var     Service
+     */
+    protected $service;
+
+    /**
+     * @param   ServiceInterface     $service
+     */
+    public function __construct(ServiceInterface $service)
+    {
+        $this->service = $service;
+    }
+
+    /**
+     * @return  Service
+     */
+    public function getService()
+    {
+        return $this->service;
+    }
+
+    /**
+     * @param   Service     $service
+     * @return  $this
+     */
+    public function setService(Service $service)
+    {
+        $this->service = $service;
+        return $this;
+    }
+
+    /**
+     * Returns whether this backend can handle a given Requirement. Requirements
+     * can be absolutely anything, so make sure to verify correctly against it.
+     *
+     * @param   mixed $requirement
+     * @return  bool
+     */
+    public function canResolve($requirement)
+    {
+        if ($requirement instanceof QueryInterface) {
+            return true;
+        }
+
+        // If it's an array, loop and check:
+        if (is_array($requirement)) {
+            foreach ($requirement as $req) {
+                if ($req instanceof QueryInterface === false) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Given a list of requirements, perform their resolutions. Requirements can
+     * be absolutely anything from strings to full-bore objects.
+     *
+     * @param   array $requirements
+     * @return  array
+     */
+    public function doResolve(array $requirements)
+    {
+        // Flatten the queries into a single array:
+        $allQueries = [];
+        $flattenMap = [];
+        foreach ($requirements as $flattenIDX => $query) {
+            if (is_array($query)) {
+                foreach ($query as $q) {
+                    $allQueries[] = $q;
+                    $flattenMap[] = $flattenIDX;
+                }
+            } else {
+                $allQueries[] = $query;
+                $flattenMap[] = $flattenIDX;
+            }
+        }
+
+        // De-dupe the queries:
+        $seenQueries = [];
+        $insertIndex = 0;
+        $resultMap = []; // result => queries needing it
+        foreach ($allQueries as $requestIdx => $query) {
+            $queryIndex = array_search($query, $seenQueries);
+            if ($queryIndex === false) {
+                $queryIndex = $insertIndex++;
+                $seenQueries[] = $query;
+            }
+            $resultMap[$queryIndex][] = $requestIdx;
+        }
+
+        // Request the data:
+        $results = $this->service->fetch($seenQueries);
+
+        // Remap the de-duping:
+        $flattenedResults = [];
+        foreach ($results as $idx => $result) {
+            $needingQueries = $resultMap[$idx];
+            foreach ($needingQueries as $qIDX) {
+                $flattenedResults[$qIDX] = $result;
+            }
+        }
+
+        ksort($flattenedResults);
+
+        // Un-flatten the result array:
+        $mappedResults = [];
+        foreach ($flattenedResults as $i => $result) {
+            $resultIndex = $flattenMap[$i];
+            if (array_key_exists($resultIndex, $mappedResults)) {
+                if (is_array($mappedResults[$resultIndex])) {
+                    $mappedResults[$resultIndex][] = $result;
+                } else {
+                    $mappedResults[$resultIndex] = [$mappedResults[$resultIndex], $result];
+                }
+            } else {
+                $mappedResults[$resultIndex] = $result;
+            }
+        }
+
+        return $mappedResults;
+    }
+}

--- a/tests/WebserviceKitResolverBackendTest.php
+++ b/tests/WebserviceKitResolverBackendTest.php
@@ -1,0 +1,448 @@
+<?php
+
+namespace BBC\iPlayerRadio\WebserviceKit\Tests;
+
+use BBC\iPlayerRadio\WebserviceKit\PHPUnit\GetMockedService;
+use BBC\iPlayerRadio\WebserviceKit\PHPUnit\LoadMockedResponse;
+use BBC\iPlayerRadio\WebserviceKit\PHPUnit\TestCase;
+use BBC\iPlayerRadio\WebserviceKit\QueryInterface;
+use BBC\iPlayerRadio\WebserviceKit\Service;
+use BBC\iPlayerRadio\WebserviceKit\Stubs\Monitoring;
+use BBC\iPlayerRadio\WebserviceKit\Stubs\ProgrammesQuery;
+use BBC\iPlayerRadio\WebserviceKit\Stubs\Query;
+use BBC\iPlayerRadio\WebserviceKit\WebserviceKitResolverBackend;
+use GuzzleHttp\Psr7\Response;
+
+class ResolverBackendTest extends TestCase
+{
+    use GetMockedService;
+    use LoadMockedResponse;
+
+    protected function preloadCache(Service $service, QueryInterface $query, $cacheData)
+    {
+        $service
+            ->getCache()
+            ->getAdapter()
+            ->save($query->getCacheKey(), $cacheData);
+    }
+
+    /* --------------- Get / Set Tests ---------------------- */
+
+    public function testGetSetService()
+    {
+        $service = $this->getMockedService();
+        $backend = new WebserviceKitResolverBackend($service);
+        $this->assertEquals($service, $backend->getService());
+
+        $newService = $this->getMockedService();
+        $newService->mark = 'green'; // this is to force PHP to copy the object.
+        $this->assertEquals($backend, $backend->setService($newService));
+        $this->assertNotEquals($service, $backend->getService());
+        $this->assertEquals($newService, $backend->getService());
+    }
+
+    /* -------------- canResolve() tests ---------------------- */
+
+    public function testCanResolvePureQuery()
+    {
+        $service = $this->getMockedService();
+
+        $backend = new WebserviceKitResolverBackend($service);
+        $query = new Query();
+
+        $this->assertTrue($backend->canResolve($query));
+    }
+
+    public function testCanResolveArrayRequirements()
+    {
+        $service = $this->getMockedService();
+        $backend = new WebserviceKitResolverBackend($service);
+
+        $query1 = (new ProgrammesQuery())->setPid('testpid0');
+        $query2 = (new ProgrammesQuery())->setPid('testpid1');
+        $query3 = (new ProgrammesQuery())->setPid('testpid2');
+
+        $this->assertTrue($backend->canResolve([$query1, $query2, $query3]));
+    }
+
+    public function testCanResolveArrayRequirementsFails()
+    {
+        $service = $this->getMockedService();
+        $backend = new WebserviceKitResolverBackend($service);
+
+        $query1 = (new ProgrammesQuery())->setPid('testpid');
+        $query2 = 'Uh-oh';
+        $query3 = (new ProgrammesQuery())->setPid('testpid2');
+
+        $this->assertFalse($backend->canResolve([$query1, $query2, $query3]));
+    }
+
+    public function testCanResolveNonObjectRequirements()
+    {
+        $service = $this->getMockedService();
+
+        $backend = new WebserviceKitResolverBackend($service);
+
+        $this->assertFalse($backend->canResolve('unknown'));
+        $this->assertFalse($backend->canResolve(27));
+        $this->assertFalse($backend->canResolve(null));
+        $this->assertFalse($backend->canResolve(false));
+        $this->assertFalse($backend->canResolve(true));
+    }
+
+    /* ------------------ doResolve() tests -------------------- */
+
+    public function testDoResolveSingleQuery()
+    {
+        $service = $this->getMockedService([
+            $this->loadMockedResponse('result1.json')
+        ]);
+
+        $backend = new WebserviceKitResolverBackend($service);
+        $query = (new ProgrammesQuery())->setPid('testpid');
+
+        $result = $backend->doResolve([$query])[0];
+
+        $this->assertInstanceOf(\stdClass::class, $result);
+        $this->assertEquals('b006qpgr', $result->pid);
+    }
+
+    public function testDoResolveMultipleQueries()
+    {
+        $service = $this->getMockedService([
+            $this->loadMockedResponse('result1.json'),
+            $this->loadMockedResponse('result2.json')
+        ]);
+
+        $backend = new WebserviceKitResolverBackend($service);
+        $query1 = (new ProgrammesQuery())->setPid('testpid');
+        $query2 = (new ProgrammesQuery())->setPid('testpid2');
+
+        $result = $backend->doResolve([$query1, $query2]);
+
+        $this->assertCount(2, $result);
+
+        $this->assertInstanceOf(\stdClass::class, $result[0]);
+        $this->assertEquals('b006qpgr', $result[0]->pid);
+
+        $this->assertInstanceOf(\stdClass::class, $result[1]);
+        $this->assertEquals('b00snr0w', $result[1]->pid);
+    }
+
+    public function testDoResolveSingleFailedQuery()
+    {
+        $service = $this->getMockedService([new Response(500)]);
+
+        $backend = new WebserviceKitResolverBackend($service);
+        $query = (new ProgrammesQuery())->setPid('testpid');
+
+        $result = $backend->doResolve([$query]);
+        $this->assertCount(1, $result);
+        $this->assertFalse($result[0]);
+    }
+
+    public function testDoResolveMultipleFailedQueries()
+    {
+        $service = $this->getMockedService([
+            new Response(500),
+            new Response(500)
+        ]);
+
+        $backend = new WebserviceKitResolverBackend($service);
+        $query1 = (new ProgrammesQuery())->setPid('testpid');
+        $query2 = (new ProgrammesQuery())->setPid('testpid2');
+
+        $result = $backend->doResolve([$query1, $query2]);
+
+        $this->assertCount(2, $result);
+        $this->assertFalse($result[0]);
+        $this->assertFalse($result[1]);
+    }
+
+    public function testDoResolveSandwichedFailure()
+    {
+        $service = $this->getMockedService([
+            $this->loadMockedResponse('result1.json'),
+            new Response(500),
+            $this->loadMockedResponse('result2.json'),
+        ]);
+
+        $backend = new WebserviceKitResolverBackend($service);
+        $query1 = (new ProgrammesQuery())->setPid('testpid');
+        $query2 = (new ProgrammesQuery())->setPid('testpid1');
+        $query3 = (new ProgrammesQuery())->setPid('testpid2');
+
+        $result = $backend->doResolve([$query1, $query2, $query3]);
+
+        $this->assertCount(3, $result);
+
+        $this->assertInstanceOf(\stdClass::class, $result[0]);
+        $this->assertEquals('b006qpgr', $result[0]->pid);
+
+        $this->assertFalse($result[1]);
+
+        $this->assertInstanceOf(\stdClass::class, $result[2]);
+        $this->assertEquals('b00snr0w', $result[2]->pid);
+    }
+
+    public function testDoResolveAllCached()
+    {
+        $service = $this->getMockedService([new Response(500), new Response(500), new Response(500)]);
+
+        $query1 = (new ProgrammesQuery())->setPid('testpid');
+        $query2 = (new ProgrammesQuery())->setPid('testpid1');
+        $query3 = (new ProgrammesQuery())->setPid('testpid2');
+
+        // Pre-load the cache:
+        /* @var     \Doctrine\Common\Cache\ArrayCache   $cache  */
+        $this->preloadCache($service, $query1, [
+            'bestBefore'    => 10,
+            'storedTime'    => time(),
+            'payload'       => ['body' => $this->loadMockedResponse('result1.json'), 'headers' => []]
+        ]);
+        $this->preloadCache($service, $query2, [
+            'bestBefore'    => 10,
+            'storedTime'    => time(),
+            'payload'       => [
+                'body' => $this->loadMockedResponse('result2.json'), 'headers' => []
+            ]
+        ]);
+        $this->preloadCache($service, $query3, [
+            'bestBefore'    => 10,
+            'storedTime'    => time(),
+            'payload'       => ['body' => $this->loadMockedResponse('result3.json'), 'headers' => []]
+        ]);
+
+
+        $backend = new WebserviceKitResolverBackend($service);
+        $result = $backend->doResolve([$query1, $query2, $query3]);
+
+        $this->assertCount(3, $result);
+
+        $this->assertInstanceOf(\stdClass::class, $result[0]);
+        $this->assertEquals('b006qpgr', $result[0]->pid);
+
+        $this->assertInstanceOf(\stdClass::class, $result[1]);
+        $this->assertEquals('b00snr0w', $result[1]->pid);
+
+        $this->assertInstanceOf(\stdClass::class, $result[2]);
+        $this->assertEquals('b006wq4s', $result[2]->pid);
+    }
+
+    public function testDoResolveFirstNeedsFetch()
+    {
+        $service = $this->getMockedService([
+            $this->loadMockedResponse('result1.json'),
+        ]);
+
+        $query1 = (new ProgrammesQuery())->setPid('testpid');
+        $query2 = (new ProgrammesQuery())->setPid('testpid1');
+        $query3 = (new ProgrammesQuery())->setPid('testpid2');
+
+        // Pre-load the cache:
+        /* @var     \Doctrine\Common\Cache\ArrayCache   $cache  */
+        $this->preloadCache($service, $query2, [
+            'bestBefore'    => 10,
+            'storedTime'    => time(),
+            'payload'       => [
+                'body' => $this->loadMockedResponse('result2.json'), 'headers' => []
+            ]
+        ]);
+        $this->preloadCache($service, $query3, [
+            'bestBefore'    => 10,
+            'storedTime'    => time(),
+            'payload'       => ['body' => $this->loadMockedResponse('result3.json'), 'headers' => []]
+        ]);
+
+
+        $backend = new WebserviceKitResolverBackend($service);
+        $result = $backend->doResolve([$query1, $query2, $query3]);
+
+        $this->assertCount(3, $result);
+
+        $this->assertInstanceOf(\stdClass::class, $result[0]);
+        $this->assertEquals('b006qpgr', $result[0]->pid);
+
+        $this->assertInstanceOf(\stdClass::class, $result[1]);
+        $this->assertEquals('b00snr0w', $result[1]->pid);
+
+        $this->assertInstanceOf(\stdClass::class, $result[2]);
+        $this->assertEquals('b006wq4s', $result[2]->pid);
+    }
+
+    public function testDoResolveSecondNeedsFetch()
+    {
+        $service = $this->getMockedService([
+            $this->loadMockedResponse('result2.json'),
+        ]);
+
+        $query1 = (new ProgrammesQuery())->setPid('testpid');
+        $query2 = (new ProgrammesQuery())->setPid('testpid1');
+        $query3 = (new ProgrammesQuery())->setPid('testpid2');
+
+        // Pre-load the cache:
+        /* @var     \Doctrine\Common\Cache\ArrayCache   $cache  */
+        $this->preloadCache($service, $query1, [
+            'bestBefore'    => 10,
+            'storedTime'    => time(),
+            'payload'       => ['body' => $this->loadMockedResponse('result1.json'), 'headers' => []]
+        ]);
+        $this->preloadCache($service, $query3, [
+            'bestBefore'    => 10,
+            'storedTime'    => time(),
+            'payload'       => ['body' => $this->loadMockedResponse('result3.json'), 'headers' => []]
+        ]);
+
+
+        $backend = new WebserviceKitResolverBackend($service);
+        $result = $backend->doResolve([$query1, $query2, $query3]);
+
+        $this->assertCount(3, $result);
+
+        $this->assertInstanceOf(\stdClass::class, $result[0]);
+        $this->assertEquals('b006qpgr', $result[0]->pid);
+
+        $this->assertInstanceOf(\stdClass::class, $result[1]);
+        $this->assertEquals('b00snr0w', $result[1]->pid);
+
+        $this->assertInstanceOf(\stdClass::class, $result[2]);
+        $this->assertEquals('b006wq4s', $result[2]->pid);
+    }
+
+    public function testDoResolveThirdNeedsFetch()
+    {
+        $service = $this->getMockedService([
+            $this->loadMockedResponse('result3.json'),
+        ]);
+
+        $query1 = (new ProgrammesQuery())->setPid('testpid');
+        $query2 = (new ProgrammesQuery())->setPid('testpid1');
+        $query3 = (new ProgrammesQuery())->setPid('testpid2');
+
+        // Pre-load the cache:
+        /* @var     \Doctrine\Common\Cache\ArrayCache   $cache  */
+        $this->preloadCache($service, $query1, [
+            'bestBefore'    => 10,
+            'storedTime'    => time(),
+            'payload'       => ['body' => $this->loadMockedResponse('result1.json'), 'headers' => []]
+        ]);
+        $this->preloadCache($service, $query2, [
+            'bestBefore'    => 10,
+            'storedTime'    => time(),
+            'payload'       => [
+                'body' => $this->loadMockedResponse('result2.json'), 'headers' => []
+            ]
+        ]);
+
+
+        $backend = new WebserviceKitResolverBackend($service);
+        $result = $backend->doResolve([$query1, $query2, $query3]);
+
+        $this->assertCount(3, $result);
+
+        $this->assertInstanceOf(\stdClass::class, $result[0]);
+        $this->assertEquals('b006qpgr', $result[0]->pid);
+
+        $this->assertInstanceOf(\stdClass::class, $result[1]);
+        $this->assertEquals('b00snr0w', $result[1]->pid);
+
+        $this->assertInstanceOf(\stdClass::class, $result[2]);
+        $this->assertEquals('b006wq4s', $result[2]->pid);
+    }
+
+    public function testDoResolveSandwich()
+    {
+        $service = $this->getMockedService([
+            $this->loadMockedResponse('result1.json'),
+            $this->loadMockedResponse('result3.json'),
+        ]);
+
+        $query1 = (new ProgrammesQuery())->setPid('testpid');
+        $query2 = (new ProgrammesQuery())->setPid('testpid1');
+        $query3 = (new ProgrammesQuery())->setPid('testpid2');
+
+        // Pre-load the cache:
+        /* @var     \Doctrine\Common\Cache\ArrayCache   $cache  */
+        $this->preloadCache($service, $query2, [
+            'bestBefore'    => 10,
+            'storedTime'    => time(),
+            'payload'       => [
+                'body' => $this->loadMockedResponse('result2.json'), 'headers' => []
+            ]
+        ]);
+
+
+        $backend = new WebserviceKitResolverBackend($service);
+        $result = $backend->doResolve([$query1, $query2, $query3]);
+
+        $this->assertCount(3, $result);
+
+        $this->assertInstanceOf(\stdClass::class, $result[0]);
+        $this->assertEquals('b006qpgr', $result[0]->pid);
+
+        $this->assertInstanceOf(\stdClass::class, $result[1]);
+        $this->assertEquals('b00snr0w', $result[1]->pid);
+
+        $this->assertInstanceOf(\stdClass::class, $result[2]);
+        $this->assertEquals('b006wq4s', $result[2]->pid);
+    }
+
+    public function testResolveArrayOfArrays()
+    {
+        $service = $this->getMockedService([
+            $this->loadMockedResponse('result1.json'),
+            $this->loadMockedResponse('result2.json'),
+            $this->loadMockedResponse('result3.json'),
+        ]);
+
+        $query1 = (new ProgrammesQuery())->setPid('testpid');
+        $query2 = (new ProgrammesQuery())->setPid('testpid1');
+        $query3 = (new ProgrammesQuery())->setPid('testpid2');
+
+        $backend = new WebserviceKitResolverBackend($service);
+        $result = $backend->doResolve([[$query1, $query2, $query3]]);
+
+        $this->assertCount(1, $result);
+        $this->assertCount(3, $result[0]);
+
+        $this->assertInstanceOf(\stdClass::class, $result[0][0]);
+        $this->assertEquals('b006qpgr', $result[0][0]->pid);
+
+        $this->assertInstanceOf(\stdClass::class, $result[0][1]);
+        $this->assertEquals('b00snr0w', $result[0][1]->pid);
+
+        $this->assertInstanceOf(\stdClass::class, $result[0][2]);
+        $this->assertEquals('b006wq4s', $result[0][2]->pid);
+    }
+
+    /* ------------- De-duplication tests -------------------- */
+
+    public function testDoResolveDuplicateQueries()
+    {
+        $service = $this->getMockedService([
+            $this->loadMockedResponse('result1.json'),
+        ]);
+
+        // Set the monitoring so we can track the number of queries.
+        $monitoring = new Monitoring();
+        $service->setMonitoring($monitoring);
+
+        $q1 = (new ProgrammesQuery())->setPid('b006qpgr');
+        $q2 = (new ProgrammesQuery())->setPid('b006qpgr');
+
+        $backend = new WebserviceKitResolverBackend($service);
+        $result = $backend->doResolve([$q1, $q2]);
+
+        $this->assertCount(2, $result);
+
+        $this->assertInstanceOf(\stdClass::class, $result[0]);
+        $this->assertEquals('b006qpgr', $result[0]->pid);
+        $this->assertInstanceOf(\stdClass::class, $result[1]);
+        $this->assertEquals('b006qpgr', $result[1]->pid);
+
+        // Ensure that only one request was made:
+        $this->assertEquals([
+            $q1->getServiceName() => 1
+        ], $monitoring->getApisCalled());
+    }
+}

--- a/tests/mock_responses/result1.json
+++ b/tests/mock_responses/result1.json
@@ -1,0 +1,4 @@
+{
+    "pid": "b006qpgr",
+    "title": "The Archers"
+}

--- a/tests/mock_responses/result2.json
+++ b/tests/mock_responses/result2.json
@@ -1,0 +1,4 @@
+{
+    "pid": "b00snr0w",
+    "title": "The Infinite Monkey Cage"
+}

--- a/tests/mock_responses/result3.json
+++ b/tests/mock_responses/result3.json
@@ -1,0 +1,4 @@
+{
+    "pid": "b006wq4s",
+    "title": "Rock Show with Daniel P Carter"
+}


### PR DESCRIPTION
So this is the re-thought implementation from the feature/v1.1.0 branch. It includes zero changes to the Service class and instead focuses just on providing a solid, de-duping implementation of a resolver backend.

This is very close to the internal implementation we use on projects and could be moved to relatively easily (can discuss our migration offline).

All tests passing and 100% coverage.